### PR TITLE
Add LinkLabel to Element::Link

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -122,9 +122,20 @@ impl Into<u8> for HeadingLevel {
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum LinkLabel<'a> {
+    /// Custom text link label.
+    ///
+    /// Can be set to any arbitrary value of the input text's choosing.
     Text(&'a str),
+
+    /// URL-mirroring link label.
+    ///
+    /// The label for this link is the same as the URL it targets.
     Url,
-    Article,
+
+    /// Article title-based link label.
+    ///
+    /// The label for this link is whatever the page's title is.
+    Page,
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -121,7 +121,7 @@ impl Into<u8> for HeadingLevel {
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub enum LinkText<'a> {
+pub enum LinkLabel<'a> {
     Text(&'a str),
     Url,
     Article,

--- a/src/parse/rule/impls/url.rs
+++ b/src/parse/rule/impls/url.rs
@@ -33,8 +33,8 @@ fn try_consume_fn<'t, 'r>(
     debug!(log, "Consuming token as a URL");
 
     let element = Element::Link {
-        label: None,
         url: extract.slice,
+        label: None,
     };
 
     Consumption::ok(element, remaining)

--- a/src/parse/rule/impls/url.rs
+++ b/src/parse/rule/impls/url.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use crate::enums::AnchorTarget;
+use crate::enums::{AnchorTarget, LinkLabel};
 
 pub const RULE_URL: Rule = Rule {
     name: "url",
@@ -35,7 +35,7 @@ fn try_consume_fn<'t, 'r>(
 
     let element = Element::Link {
         url: extract.slice,
-        label: None,
+        label: LinkLabel::Url,
         anchor: AnchorTarget::Same,
     };
 

--- a/src/parse/rule/impls/url.rs
+++ b/src/parse/rule/impls/url.rs
@@ -19,6 +19,7 @@
  */
 
 use super::prelude::*;
+use crate::enums::AnchorTarget;
 
 pub const RULE_URL: Rule = Rule {
     name: "url",
@@ -35,6 +36,7 @@ fn try_consume_fn<'t, 'r>(
     let element = Element::Link {
         url: extract.slice,
         label: None,
+        anchor: AnchorTarget::Same,
     };
 
     Consumption::ok(element, remaining)

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -19,6 +19,7 @@
  */
 
 use super::Container;
+use crate::enums::AnchorTarget;
 
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", tag = "variant", content = "data")]
@@ -48,6 +49,7 @@ pub enum Element<'a> {
     Link {
         url: &'a str,
         label: Option<&'a str>,
+        anchor: AnchorTarget,
     },
 
     /// A newline or line break.

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -26,7 +26,7 @@ use crate::enums::AnchorTarget;
 pub enum Element<'a> {
     /// An element which contains other elements within it.
     ///
-    /// Examples would include bold, italics, divs, etc.
+    /// Examples would include italics, paragraphs, divs, etc.
     Container(Container<'a>),
 
     /// An element only containing text.

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -19,7 +19,7 @@
  */
 
 use super::Container;
-use crate::enums::AnchorTarget;
+use crate::enums::{AnchorTarget, LinkLabel};
 
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", tag = "variant", content = "data")]
@@ -48,7 +48,7 @@ pub enum Element<'a> {
     /// The "url" field is either a page name (relative URL) or full URL.
     Link {
         url: &'a str,
-        label: Option<&'a str>,
+        label: LinkLabel<'a>,
         anchor: AnchorTarget,
     },
 

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -41,12 +41,13 @@ pub enum Element<'a> {
 
     /// An element linking to a different page.
     ///
-    /// The "url" field is either a page name (relative URL) or full URL.
     /// The "label" field is an optional field denoting what the link should
     /// display. If `None`, use the link's value itself, that is, `label.unwrap_or(url)`.
+    ///
+    /// The "url" field is either a page name (relative URL) or full URL.
     Link {
-        label: Option<&'a str>,
         url: &'a str,
+        label: Option<&'a str>,
     },
 
     /// A newline or line break.


### PR DESCRIPTION
Allows us to be more precise about specifying the label of a link. This PR also renames `LinkText -> LinkLabel` and adds documentation to the variants.