### PR TITLE
Add rule implementation for raw syntax

### DIFF
--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -46,6 +46,23 @@ impl ParseError {
         }
     }
 
+    /// Raw `ParseError` constructor for tests.
+    #[inline]
+    #[cfg(test)]
+    pub(crate) fn new_raw(
+        token: Token,
+        rule: &'static str,
+        span: Range<usize>,
+        kind: ParseErrorKind,
+    ) -> Self {
+        ParseError {
+            token,
+            rule,
+            span,
+            kind,
+        }
+    }
+
     #[inline]
     pub fn token(&self) -> Token {
         self.token

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -79,6 +79,9 @@ pub enum ParseErrorKind {
     /// Attempting to process this rule failed because the end of input was reached.
     EndOfInput,
 
+    /// Temporary rule denoting that this syntactical construction isn't implemented yet.
+    NotImplemented,
+
     /// No rules match for these tokens, returning as plain text.
     NoRulesMatch,
 }

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -76,6 +76,9 @@ pub enum ParseErrorKind {
     /// Attempting to match this rule failed, falling back to try an alternate.
     RuleFailed,
 
+    /// Attempting to process this rule failed because the end of input was reached.
+    EndOfInput,
+
     /// No rules match for these tokens, returning as plain text.
     NoRulesMatch,
 }

--- a/src/parse/rule/impls/comment.rs
+++ b/src/parse/rule/impls/comment.rs
@@ -63,7 +63,7 @@ fn try_consume_fn<'t, 'r>(
                 trace!(log, "Reached end of input, aborting comment.");
 
                 return Consumption::err(ParseError::new(
-                    ParseErrorKind::RuleFailed,
+                    ParseErrorKind::EndOfInput,
                     RULE_COMMENT,
                     new_extracted,
                 ));

--- a/src/parse/rule/impls/comment.rs
+++ b/src/parse/rule/impls/comment.rs
@@ -53,14 +53,14 @@ fn try_consume_fn<'t, 'r>(
         match token {
             // Hit the end of the comment, return
             Token::RightComment => {
-                trace!(log, "Reached end of comment, finishing comment.");
+                trace!(log, "Reached end of comment, returning");
 
                 return Consumption::ok(Element::Null, new_remaining);
             }
 
             // Hit the end of the input, abort
             Token::InputEnd => {
-                trace!(log, "Reached end of input, aborting comment.");
+                trace!(log, "Reached end of input, aborting");
 
                 return Consumption::err(ParseError::new(
                     ParseErrorKind::EndOfInput,
@@ -69,7 +69,7 @@ fn try_consume_fn<'t, 'r>(
                 ));
             }
 
-            // Consume any other comment
+            // Consume any other token
             _ => {
                 trace!(log, "Token inside comment received. Discarding.");
 

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -34,6 +34,7 @@ mod fallback;
 mod italics;
 mod line_break;
 mod null;
+mod raw;
 mod text;
 mod url;
 
@@ -44,5 +45,6 @@ pub use self::fallback::RULE_FALLBACK;
 pub use self::italics::RULE_ITALICS;
 pub use self::line_break::RULE_LINE_BREAK;
 pub use self::null::RULE_NULL;
+pub use self::raw::RULE_RAW;
 pub use self::text::RULE_TEXT;
 pub use self::url::RULE_URL;

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -36,6 +36,7 @@ mod line_break;
 mod null;
 mod raw;
 mod text;
+mod todo;
 mod url;
 
 pub use self::bold::RULE_BOLD;
@@ -47,4 +48,5 @@ pub use self::line_break::RULE_LINE_BREAK;
 pub use self::null::RULE_NULL;
 pub use self::raw::RULE_RAW;
 pub use self::text::RULE_TEXT;
+pub use self::todo::RULE_TODO;
 pub use self::url::RULE_URL;

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -76,7 +76,7 @@ fn try_consume_fn<'t, 'r>(
             (Token::Raw, _) => {
                 debug!(log, "Found empty raw (\"@@@@\"), returning");
 
-                return Consumption::ok(Element::Raw(vec![""]), &remaining[1..]);
+                return Consumption::ok(Element::Raw(vec![]), &remaining[1..]);
             }
 
             // "@@ <invalid> @@" -> Abort

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -1,0 +1,92 @@
+/*
+ * parse/rule/impls/raw.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+
+pub const RULE_RAW: Rule = Rule {
+    name: "raw",
+    try_consume_fn,
+};
+
+fn try_consume_fn<'t, 'r>(
+    log: &slog::Logger,
+    extracted: &'r ExtractedToken<'t>,
+    mut remaining: &'r [ExtractedToken<'t>],
+) -> Consumption<'t, 'r> {
+    debug!(log, "Consuming tokens until end of raw");
+
+    // Are we in a @@..@@ type raw, or a @<..>@ type?
+    let ending_token = match extracted.token {
+        Token::Raw => Token::Raw,
+        Token::LeftRaw => Token::RightRaw,
+        _ => panic!("Current token is not a starting raw"),
+    };
+
+    //TODO:
+    //four cases needed here:
+    // Raw Raw !Raw -> Element::Raw("")
+    // Raw Raw Raw -> Element::Raw("@@")
+    //
+    // Raw ... Raw -> Element::Raw(" ... ")
+    // LeftRaw ... RightRaw -> Element::Raw(" ... ")
+
+    while let Some((new_extracted, new_remaining)) = remaining.split_first() {
+        let ExtractedToken { token, span, slice } = new_extracted;
+        debug!(
+            log,
+            "Received token inside raw";
+            "token" => token,
+            "slice" => slice,
+            "span-start" => span.start,
+            "span-end" => span.end,
+        );
+
+        // Check token
+        match token {
+            // Hit the end of the comment, return
+            Token::RightComment => {
+                trace!(log, "Reached end of comment, finishing comment.");
+
+                return Consumption::ok(Element::Null, new_remaining);
+            }
+
+            // Hit the end of the input, abort
+            Token::InputEnd => {
+                trace!(log, "Reached end of input, aborting comment.");
+
+                return Consumption::err(ParseError::new(
+                    ParseErrorKind::RuleFailed,
+                    RULE_RAW,
+                    new_extracted,
+                ));
+            }
+
+            // Consume any other comment
+            _ => {
+                trace!(log, "Token inside comment received. Discarding.");
+
+                // Update pointer
+                remaining = new_remaining;
+            }
+        }
+    }
+
+    panic!("Reached end of input without encountering a Token::InputEnd");
+}

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -54,15 +54,15 @@ fn try_consume_fn<'t, 'r>(
 
         let next_extracted_1 = &remaining[0];
         let next_extracted_2 = &remaining[1];
-        let new_remaining = &remaining[2..];
 
         // Determine which case they fall under
         match (next_extracted_1.token, next_extracted_2.token) {
             // "@@@@@@" -> Element::Raw("@@")
-            (Token::Raw, Token::Raw) => return Consumption::ok(Element::Raw("@@"), new_remaining),
+            (Token::Raw, Token::Raw) => return Consumption::ok(Element::Raw("@@"), &remaining[2..]),
 
             // "@@@@" -> Element::Raw("")
-            (Token::Raw, _) => return Consumption::ok(Element::Raw(""), new_remaining),
+            // Only consumes two tokens.
+            (Token::Raw, _) => return Consumption::ok(Element::Raw(""), &remaining[1..]),
 
             // "@@ <invalid> @@" -> Abort
             (Token::LineBreak, Token::Raw) | (Token::ParagraphBreak, Token::Raw) => {
@@ -75,7 +75,7 @@ fn try_consume_fn<'t, 'r>(
 
             // "@@ <something> @@" -> Element::Raw(token)
             (_, Token::Raw) => {
-                return Consumption::ok(Element::Raw(next_extracted_1.slice), new_remaining)
+                return Consumption::ok(Element::Raw(next_extracted_1.slice), &remaining[2..])
             }
 
             // Other, proceed with rule logic

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -94,7 +94,7 @@ fn try_consume_fn<'t, 'r>(
                 return Consumption::ok(Element::Raw(vec![]), &remaining[1..]);
             }
 
-            // "@@ <invalid> @@" -> Abort
+            // "@@ \n @@" -> Abort
             (Token::LineBreak, Token::Raw) | (Token::ParagraphBreak, Token::Raw) => {
                 debug!(log, "Found interrupted raw, aborting");
 

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -71,6 +71,19 @@ fn try_consume_fn<'t, 'r>(
                 return Consumption::ok(Element::Raw(vec!["@@"]), &remaining[2..]);
             }
 
+            // "@@@@@" -> Element::Raw("@")
+            // This case is strange since the lexer returns Raw Raw Other (@@ @@ @)
+            // So we capture this and return the intended output
+            (Token::Raw, Token::Other) => {
+                if next_extracted_2.slice == "@" {
+                    debug!(log, "Found single-raw (\"@@@@@\"), returning");
+                    return Consumption::ok(Element::Raw(vec!["@"]), &remaining[2..]);
+                } else {
+                    debug!(log, "Found empty raw (\"@@@@\"), followed by other text");
+                    return Consumption::ok(Element::Raw(vec![""]), &remaining[1..]);
+                }
+            }
+
             // "@@@@" -> Element::Raw("")
             // Only consumes two tokens.
             (Token::Raw, _) => {

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -178,6 +178,7 @@ fn try_consume_fn<'t, 'r>(
         }
 
         trace!(log, "Appending present token to raw");
+
         // Append slice and update pointer
         slices.push(slice);
         remaining = new_remaining;

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -39,9 +39,11 @@ fn try_consume_fn<'t, 'r>(
         _ => panic!("Current token is not a starting raw"),
     };
 
-    // Check for two special cases:
+    // Check for four special cases:
+    // * Raw Raw  "@" -> Element::Raw("@")
     // * Raw Raw !Raw -> Element::Raw("")
     // * Raw Raw  Raw -> Element::Raw("@@")
+    // * Raw ??   Raw -> Element::Raw(slice)
     if ending_token == Token::Raw {
         trace!(log, "First token is '@@', checking for special cases");
 

--- a/src/parse/rule/impls/todo.rs
+++ b/src/parse/rule/impls/todo.rs
@@ -1,0 +1,41 @@
+/*
+ * parse/rule/impls/todo.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+
+/// Temporary rule for syntactical constructions that are not yet implemented.
+pub const RULE_TODO: Rule = Rule {
+    name: "todo",
+    try_consume_fn,
+};
+
+fn try_consume_fn<'t, 'r>(
+    log: &slog::Logger,
+    extracted: &'r ExtractedToken<'t>,
+    _: &'r [ExtractedToken<'t>],
+) -> Consumption<'t, 'r> {
+    error!(log, "Encountered unimplemented rule! Returning error");
+
+    Consumption::err(ParseError::new(
+        ParseErrorKind::NotImplemented,
+        RULE_TODO,
+        extracted,
+    ))
+}

--- a/src/parse/rule/mapping.rs
+++ b/src/parse/rule/mapping.rs
@@ -34,64 +34,64 @@ lazy_static! {
     pub static ref RULE_MAP: EnumMap<Token, Vec<Rule>> = {
         enum_map! {
             // Symbols
-            Token::LeftBracket => vec![],
-            Token::RightBracket => vec![],
-            Token::LeftTag => vec![],
-            Token::LeftTagAnchor => vec![],
-            Token::LeftTagSpecial => vec![],
-            Token::RightTag => vec![],
-            Token::RightTagEnd => vec![],
-            Token::LeftAnchor => vec![],
-            Token::DoubleDash => vec![],
-            Token::TripleDash => vec![],
-            Token::Pipe => vec![],
-            Token::Equals => vec![],
-            Token::Quote => vec![],
-            Token::Heading => vec![],
+            Token::LeftBracket => vec![RULE_TODO], // TODO
+            Token::RightBracket => vec![RULE_TODO], // TODO
+            Token::LeftTag => vec![RULE_TODO], // TODO
+            Token::LeftTagAnchor => vec![RULE_TODO], // TODO
+            Token::LeftTagSpecial => vec![RULE_TODO], // TODO
+            Token::RightTag => vec![RULE_TODO], // TODO
+            Token::RightTagEnd => vec![RULE_TODO], // TODO
+            Token::LeftAnchor => vec![RULE_TODO], // TODO
+            Token::DoubleDash => vec![RULE_TODO], // TODO
+            Token::TripleDash => vec![RULE_TODO], // TODO
+            Token::Pipe => vec![RULE_TODO], // TODO
+            Token::Equals => vec![RULE_TODO], // TODO
+            Token::Quote => vec![RULE_TODO], // TODO
+            Token::Heading => vec![RULE_TODO], // TODO
             Token::LineBreak => vec![RULE_LINE_BREAK],
-            Token::ParagraphBreak => vec![],
+            Token::ParagraphBreak => vec![RULE_TODO], // TODO
             Token::Whitespace => vec![RULE_TEXT],
 
             // Formatting
             Token::Bold => vec![RULE_BOLD],
             Token::Italics => vec![RULE_ITALICS],
-            Token::Underline => vec![],
-            Token::Superscript => vec![],
-            Token::Subscript => vec![],
-            Token::LeftMonospace => vec![],
-            Token::RightMonospace => vec![],
-            Token::Color => vec![],
+            Token::Underline => vec![RULE_TODO], // TODO
+            Token::Superscript => vec![RULE_TODO], // TODO
+            Token::Subscript => vec![RULE_TODO], // TODO
+            Token::LeftMonospace => vec![RULE_TODO], // TODO
+            Token::RightMonospace => vec![RULE_TODO], // TODO
+            Token::Color => vec![RULE_TODO], // TODO
             Token::Raw => vec![RULE_RAW],
             Token::LeftRaw => vec![RULE_RAW],
-            Token::RightRaw => vec![],
+            Token::RightRaw => vec![RULE_TODO], // TODO
 
             // Links
-            Token::LeftLink => vec![],
-            Token::RightLink => vec![],
+            Token::LeftLink => vec![RULE_TODO], // TODO
+            Token::RightLink => vec![RULE_TODO], // TODO
 
             // Tables
-            Token::TableColumn => vec![],
-            Token::TableColumnTitle => vec![],
+            Token::TableColumn => vec![RULE_TODO], // TODO
+            Token::TableColumnTitle => vec![RULE_TODO], // TODO
 
             // Alignment
-            Token::RightAlignOpen => vec![],
-            Token::RightAlignClose => vec![],
-            Token::LeftAlignOpen => vec![],
-            Token::LeftAlignClose => vec![],
-            Token::CenterAlignOpen => vec![],
-            Token::CenterAlignClose => vec![],
-            Token::JustifyAlignOpen => vec![],
-            Token::JustifyAlignClose => vec![],
+            Token::RightAlignOpen => vec![RULE_TODO], // TODO
+            Token::RightAlignClose => vec![RULE_TODO], // TODO
+            Token::LeftAlignOpen => vec![RULE_TODO], // TODO
+            Token::LeftAlignClose => vec![RULE_TODO], // TODO
+            Token::CenterAlignOpen => vec![RULE_TODO], // TODO
+            Token::CenterAlignClose => vec![RULE_TODO], // TODO
+            Token::JustifyAlignOpen => vec![RULE_TODO], // TODO
+            Token::JustifyAlignClose => vec![RULE_TODO], // TODO
 
             // Text components
             Token::Identifier => vec![RULE_TEXT],
             Token::Email => vec![RULE_EMAIL],
             Token::Url => vec![RULE_URL],
-            Token::String => vec![],
+            Token::String => vec![RULE_TODO], // TODO
 
             // Miscellaneous
             Token::LeftComment => vec![RULE_COMMENT],
-            Token::RightComment => vec![],
+            Token::RightComment => vec![RULE_TODO], // TODO
             Token::InputEnd => vec![RULE_NULL],
 
             // Fallback

--- a/src/parse/rule/mapping.rs
+++ b/src/parse/rule/mapping.rs
@@ -34,8 +34,8 @@ lazy_static! {
     pub static ref RULE_MAP: EnumMap<Token, Vec<Rule>> = {
         enum_map! {
             // Symbols
-            Token::LeftBracket => vec![RULE_TODO], // TODO
-            Token::RightBracket => vec![],
+            Token::LeftBracket => vec![RULE_TODO, RULE_TEXT], // TODO
+            Token::RightBracket => vec![RULE_TEXT],
             Token::LeftTag => vec![RULE_TODO], // TODO
             Token::LeftTagAnchor => vec![RULE_TODO], // TODO
             Token::LeftTagSpecial => vec![RULE_TODO], // TODO
@@ -44,10 +44,10 @@ lazy_static! {
             Token::LeftAnchor => vec![RULE_TODO], // TODO
             Token::DoubleDash => vec![RULE_TODO], // TODO
             Token::TripleDash => vec![RULE_TODO], // TODO
-            Token::Pipe => vec![RULE_TODO], // TODO
-            Token::Equals => vec![RULE_TODO], // TODO
+            Token::Pipe => vec![RULE_TEXT],
+            Token::Equals => vec![RULE_TODO, RULE_TEXT], // TODO
             Token::Quote => vec![RULE_TODO], // TODO
-            Token::Heading => vec![RULE_TODO], // TODO
+            Token::Heading => vec![RULE_TODO, RULE_TEXT], // TODO
             Token::LineBreak => vec![RULE_LINE_BREAK],
             Token::ParagraphBreak => vec![RULE_TODO], // TODO
             Token::Whitespace => vec![RULE_TEXT],
@@ -87,7 +87,7 @@ lazy_static! {
             Token::Identifier => vec![RULE_TEXT],
             Token::Email => vec![RULE_EMAIL],
             Token::Url => vec![RULE_URL],
-            Token::String => vec![RULE_TODO], // TODO
+            Token::String => vec![RULE_TEXT],
 
             // Miscellaneous
             Token::LeftComment => vec![RULE_COMMENT],

--- a/src/parse/rule/mapping.rs
+++ b/src/parse/rule/mapping.rs
@@ -35,12 +35,12 @@ lazy_static! {
         enum_map! {
             // Symbols
             Token::LeftBracket => vec![RULE_TODO], // TODO
-            Token::RightBracket => vec![RULE_TODO], // TODO
+            Token::RightBracket => vec![],
             Token::LeftTag => vec![RULE_TODO], // TODO
             Token::LeftTagAnchor => vec![RULE_TODO], // TODO
             Token::LeftTagSpecial => vec![RULE_TODO], // TODO
-            Token::RightTag => vec![RULE_TODO], // TODO
-            Token::RightTagEnd => vec![RULE_TODO], // TODO
+            Token::RightTag => vec![],
+            Token::RightTagEnd => vec![],
             Token::LeftAnchor => vec![RULE_TODO], // TODO
             Token::DoubleDash => vec![RULE_TODO], // TODO
             Token::TripleDash => vec![RULE_TODO], // TODO
@@ -63,11 +63,11 @@ lazy_static! {
             Token::Color => vec![RULE_TODO], // TODO
             Token::Raw => vec![RULE_RAW],
             Token::LeftRaw => vec![RULE_RAW],
-            Token::RightRaw => vec![RULE_TODO], // TODO
+            Token::RightRaw => vec![],
 
             // Links
             Token::LeftLink => vec![RULE_TODO], // TODO
-            Token::RightLink => vec![RULE_TODO], // TODO
+            Token::RightLink => vec![],
 
             // Tables
             Token::TableColumn => vec![RULE_TODO], // TODO
@@ -75,13 +75,13 @@ lazy_static! {
 
             // Alignment
             Token::RightAlignOpen => vec![RULE_TODO], // TODO
-            Token::RightAlignClose => vec![RULE_TODO], // TODO
+            Token::RightAlignClose => vec![],
             Token::LeftAlignOpen => vec![RULE_TODO], // TODO
-            Token::LeftAlignClose => vec![RULE_TODO], // TODO
+            Token::LeftAlignClose => vec![],
             Token::CenterAlignOpen => vec![RULE_TODO], // TODO
-            Token::CenterAlignClose => vec![RULE_TODO], // TODO
+            Token::CenterAlignClose => vec![],
             Token::JustifyAlignOpen => vec![RULE_TODO], // TODO
-            Token::JustifyAlignClose => vec![RULE_TODO], // TODO
+            Token::JustifyAlignClose => vec![],
 
             // Text components
             Token::Identifier => vec![RULE_TEXT],
@@ -91,7 +91,7 @@ lazy_static! {
 
             // Miscellaneous
             Token::LeftComment => vec![RULE_COMMENT],
-            Token::RightComment => vec![RULE_TODO], // TODO
+            Token::RightComment => vec![],
             Token::InputEnd => vec![RULE_NULL],
 
             // Fallback

--- a/src/parse/rule/mapping.rs
+++ b/src/parse/rule/mapping.rs
@@ -23,6 +23,14 @@ use crate::parse::token::{ExtractedToken, Token};
 use enum_map::EnumMap;
 
 lazy_static! {
+    /// Mapping of all tokens to the rules they possibly correspond with.
+    ///
+    /// This is the first tokens that could consistute the given rule,
+    /// in order of precedence.
+    ///
+    /// An empty list means that this is a special token that shouldn't be used
+    /// in this manner. It will of course fall back to interpreting this token
+    /// as text, but will also produce an error for the user.
     pub static ref RULE_MAP: EnumMap<Token, Vec<Rule>> = {
         enum_map! {
             // Symbols

--- a/src/parse/rule/mapping.rs
+++ b/src/parse/rule/mapping.rs
@@ -53,8 +53,8 @@ lazy_static! {
             Token::LeftMonospace => vec![],
             Token::RightMonospace => vec![],
             Token::Color => vec![],
-            Token::Raw => vec![],
-            Token::LeftRaw => vec![],
+            Token::Raw => vec![RULE_RAW],
+            Token::LeftRaw => vec![RULE_RAW],
             Token::RightRaw => vec![],
 
             // Links

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -110,6 +110,22 @@ fn ast() {
     );
 
     test!(
+        "//fail italics",
+        vec![
+            Element::Text("//"),
+            Element::Text("fail"),
+            Element::Text(" "),
+            Element::Text("italics"),
+        ],
+        vec![ParseError::new_raw(
+            Token::Italics,
+            "fallback",
+            0..2,
+            ParseErrorKind::NoRulesMatch,
+        )],
+    );
+
+    test!(
         "single [!-- stuff here --] comment",
         vec![
             Element::Text("single"),

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -293,7 +293,7 @@ fn ast() {
                 ParseErrorKind::NoRulesMatch,
             ),
             // Trying the ending raw as an opener
-            ParseError::new_raw(Token::Raw, "fallback", 15..17, ParseErrorKind::NoRulesMatch,),
+            ParseError::new_raw(Token::RightRaw, "fallback", 15..17, ParseErrorKind::NoRulesMatch),
         ],
     );
 }

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -188,13 +188,9 @@ fn ast() {
 
     test!("@@@@", vec![Element::Raw(vec![])], vec![]);
 
-    test!("@@@@@@", vec![Element::Raw(vec!["@@"])], vec![]);
+    test!("@@@@@", vec![Element::Raw(vec!["@"])], vec![]);
 
-    // This one's kind of dumb, since it interprets it as empty raw (@@@@)
-    // followed by a literal at-sign (@).
-    //
-    // But it has the inteded output, so I don't care too much, to be honest...
-    test!("@@@@@", vec![Element::Raw(vec![]), Element::Text("@")], vec![]);
+    test!("@@@@@@", vec![Element::Raw(vec!["@@"])], vec![]);
 
     test!(
         "test @@@@ string",

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -147,6 +147,40 @@ fn ast() {
         ],
         vec![],
     );
+
+    test!(
+        "fail [!-- comment",
+        vec![
+            Element::Text("fail"),
+            Element::Text(" "),
+            Element::Text("[!--"),
+            Element::Text(" "),
+            Element::Text("comment"),
+        ],
+        vec![ParseError::new_raw(
+            Token::LeftComment,
+            "fallback",
+            5..9,
+            ParseErrorKind::NoRulesMatch,
+        )],
+    );
+
+    test!(
+        "fail --] comment",
+        vec![
+            Element::Text("fail"),
+            Element::Text(" "),
+            Element::Text("--]"),
+            Element::Text(" "),
+            Element::Text("comment"),
+        ],
+        vec![ParseError::new_raw(
+            Token::RightComment,
+            "fallback",
+            5..8,
+            ParseErrorKind::NoRulesMatch,
+        )],
+    );
 }
 
 #[test]

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -71,7 +71,11 @@ fn ast() {
 
     test!("", vec![], vec![]);
 
+    test!(" ", vec![Element::Text(" ")], vec![]);
+
     test!("abc", vec![Element::Text("abc")], vec![]);
+
+    test!("\n", vec![Element::LineBreak], vec![]);
 
     test!(
         "**bold** text",

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use crate::parse::{ParseError, ParseErrorKind, Token};
 use crate::tree::{Container, ContainerType, Element, SyntaxTree};
 
 #[test]
@@ -80,6 +81,22 @@ fn ast() {
             Element::Text("text"),
         ],
         vec![],
+    );
+
+    test!(
+        "**fail bold",
+        vec![
+            Element::Text("**"),
+            Element::Text("fail"),
+            Element::Text(" "),
+            Element::Text("bold"),
+        ],
+        vec![ParseError::new_raw(
+            Token::Bold,
+            "fallback",
+            0..2,
+            ParseErrorKind::NoRulesMatch,
+        )],
     );
 
     test!(

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -190,6 +190,12 @@ fn ast() {
 
     test!("@@@@@@", vec![Element::Raw(vec!["@@"])], vec![]);
 
+    // This one's kind of dumb, since it interprets it as empty raw (@@@@)
+    // followed by a literal at-sign (@).
+    //
+    // But it has the inteded output, so I don't care too much, to be honest...
+    test!("@@@@@", vec![Element::Raw(vec![]), Element::Text("@")], vec![]);
+
     test!(
         "test @@@@ string",
         vec![

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -217,6 +217,12 @@ fn ast() {
     );
 
     test!(
+        "@<>@",
+        vec![Element::Raw(vec![])],
+        vec![],
+    );
+
+    test!(
         "@@raw @< >@ content@@",
         vec![Element::Raw(vec![
             "raw", " ", "@<", " ", ">@", " ", "content",

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -45,6 +45,9 @@ fn ast() {
             let (tree, errors) = result.into();
             let SyntaxTree { elements } = tree;
 
+            println!("Actual elements: {:#?}", elements);
+            println!("Actual errors: {:#?}", errors);
+
             assert_eq!(
                 elements,
                 expected_elements,
@@ -85,6 +88,29 @@ fn ast() {
             container!(Italics, vec![Element::Text("italics")]),
             Element::Text(" "),
             Element::Text("text"),
+        ],
+        vec![],
+    );
+
+    test!(
+        "single [!-- stuff here --] comment",
+        vec![
+            Element::Text("single"),
+            Element::Text(" "),
+            Element::Text(" "),
+            Element::Text("comment"),
+        ],
+        vec![],
+    );
+
+    test!(
+        "multiline\n[!-- stuff \n here --]\n comment",
+        vec![
+            Element::Text("multiline"),
+            Element::LineBreak,
+            Element::LineBreak,
+            Element::Text(" "),
+            Element::Text("comment"),
         ],
         vec![],
     );

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -216,11 +216,7 @@ fn ast() {
         vec![],
     );
 
-    test!(
-        "@<>@",
-        vec![Element::Raw(vec![])],
-        vec![],
-    );
+    test!("@<>@", vec![Element::Raw(vec![])], vec![],);
 
     test!(
         "@@raw @< >@ content@@",
@@ -293,7 +289,12 @@ fn ast() {
                 ParseErrorKind::NoRulesMatch,
             ),
             // Trying the ending raw as an opener
-            ParseError::new_raw(Token::RightRaw, "fallback", 15..17, ParseErrorKind::NoRulesMatch),
+            ParseError::new_raw(
+                Token::RightRaw,
+                "fallback",
+                15..17,
+                ParseErrorKind::NoRulesMatch,
+            ),
         ],
     );
 }

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -241,6 +241,55 @@ fn ast() {
         vec![Element::Raw(vec!["raw", " ", "@@", " ", "content"])],
         vec![],
     );
+
+    test!(
+        "interrupted @@\n@@",
+        vec![
+            Element::Text("interrupted"),
+            Element::Text(" "),
+            Element::Text("@@"),
+            Element::LineBreak,
+            Element::Text("@@"),
+        ],
+        vec![
+            // From interrupted raw
+            ParseError::new_raw(
+                Token::Raw, //
+                "fallback",
+                12..14,
+                ParseErrorKind::NoRulesMatch,
+            ),
+            // Trying the ending raw as an opener
+            ParseError::new_raw(
+                Token::Raw, //
+                "fallback",
+                15..17,
+                ParseErrorKind::NoRulesMatch,
+            ),
+        ],
+    );
+
+    test!(
+        "interrupted @<\n>@",
+        vec![
+            Element::Text("interrupted"),
+            Element::Text(" "),
+            Element::Text("@<"),
+            Element::LineBreak,
+            Element::Text(">@"),
+        ],
+        vec![
+            // From interrupted raw
+            ParseError::new_raw(
+                Token::LeftRaw,
+                "fallback",
+                12..14,
+                ParseErrorKind::NoRulesMatch,
+            ),
+            // Trying the ending raw as an opener
+            ParseError::new_raw(Token::Raw, "fallback", 15..17, ParseErrorKind::NoRulesMatch,),
+        ],
+    );
 }
 
 #[test]

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -181,6 +181,60 @@ fn ast() {
             ParseErrorKind::NoRulesMatch,
         )],
     );
+
+    test!("@@@@", vec![Element::Raw(vec![])], vec![]);
+
+    test!("@@@@@@", vec![Element::Raw(vec!["@@"])], vec![]);
+
+    test!(
+        "test @@@@ string",
+        vec![
+            Element::Text("test"),
+            Element::Text(" "),
+            Element::Raw(vec![]),
+            Element::Text(" "),
+            Element::Text("string"),
+        ],
+        vec![],
+    );
+
+    test!(
+        "test @@@@@@ string",
+        vec![
+            Element::Text("test"),
+            Element::Text(" "),
+            Element::Raw(vec!["@@"]),
+            Element::Text(" "),
+            Element::Text("string"),
+        ],
+        vec![],
+    );
+
+    test!(
+        "@@raw @< >@ content@@",
+        vec![Element::Raw(vec![
+            "raw", " ", "@<", " ", ">@", " ", "content",
+        ])],
+        vec![],
+    );
+
+    test!(
+        "not @@**@@ bold",
+        vec![
+            Element::Text("not"),
+            Element::Text(" "),
+            Element::Raw(vec!["**"],),
+            Element::Text(" "),
+            Element::Text("bold"),
+        ],
+        vec![],
+    );
+
+    test!(
+        "@<raw @@ content>@",
+        vec![Element::Raw(vec!["raw", " ", "@@", " ", "content"])],
+        vec![],
+    );
 }
 
 #[test]

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -39,7 +39,7 @@ pub enum Element<'a> {
     /// This should be formatted exactly as listed.
     /// For instance, spaces being rendered to HTML should
     /// produce a `&nbsp;`.
-    Raw(&'a str),
+    Raw(Vec<&'a str>),
 
     /// An element indicating an email.
     ///


### PR DESCRIPTION
Wikidot supports "raw expressions", or those that aren't parsed as tokens but rather as raw text.

For instance:
* `@@apple@@` -> `apple`
* `@@**@@` -> `**`
* `@<alternate // syntax>@` -> `alternate // syntax`
* `@<@@>@` -> `@@`
* `@@@@` -> (empty string)
* `@@@@@` -> `@`
* `@@@@@@` -> `@@`

They are wrapped in either `@@ ... @@` or `@< ... >@`, and do _not_ go across newlines.