### PR TITLE
Add the color container element to ftml

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ There are three exported functions, which correspond to each of the main steps i
 
 First is `preprocess`, which will perform Wikidot's various minor text substitutions.
 
-Second is `tokenize`, which takes the input string and returns a wrapper type. This type contains both the list of extracted tokens (borrow-able with `.tokens()`, or own-able with `.into()`), and the original input string. This is used as the input for `parse`.
+Second is `tokenize`, which takes the input string and returns a wrapper type. This can be `.into()`-ed into a `Vec<ExtractedToken<'t>>` should you want the token extractions it produced. This is used as the input for `parse`.
 
 Then, borrowing a slice of said tokens, `parse` consumes them and produces a `SyntaxTree` representing the full structure of the parsed wikitext.
 
@@ -94,11 +94,11 @@ fn preprocess(
 fn tokenize<'t>(
     log: &slog::Logger,
     text: &'t str,
-) -> Vec<ExtractedToken<'t>>;
+) -> Tokenization<'t>;
 
 fn parse<'r, 't>(
     log: &slog::Logger,
-    tokens: &'r [ExtractedToken<'t>],
+    tokenization: &'r Tokenization<'t>,
 ) -> ParseResult<SyntaxTree<'t>>;
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,14 +69,14 @@ mod enums;
 mod parse;
 mod preproc;
 mod text;
+mod tokenize;
 
 pub mod data;
 pub mod tree;
 
-pub use self::parse::{
-    parse, tokenize, ExtractedToken, ParseError, ParseErrorKind, ParseResult, Token,
-};
+pub use self::parse::{parse, ExtractedToken, ParseError, ParseErrorKind, ParseResult, Token};
 pub use self::preproc::preprocess;
+pub use self::tokenize::{tokenize, Tokenization};
 
 pub mod prelude {
     pub use super::tree::{Element, SyntaxTree};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ mod log;
 mod enums;
 mod parse;
 mod preproc;
+mod text;
 
 pub mod data;
 pub mod tree;

--- a/src/parse/consume.rs
+++ b/src/parse/consume.rs
@@ -68,5 +68,5 @@ pub fn consume<'t, 'r>(
     let element = Element::Text(slice);
     let error = ParseError::new(ParseErrorKind::NoRulesMatch, RULE_FALLBACK, extracted);
 
-    Consumption::warn(element, remaining, error)
+    Consumption::warn(element, remaining, Some(error))
 }

--- a/src/parse/consume.rs
+++ b/src/parse/consume.rs
@@ -68,5 +68,5 @@ pub fn consume<'t, 'r>(
     let element = Element::Text(slice);
     let error = ParseError::new(ParseErrorKind::NoRulesMatch, RULE_FALLBACK, extracted);
 
-    Consumption::warn(element, remaining, Some(error))
+    Consumption::warn(element, remaining, vec![error])
 }

--- a/src/parse/consume.rs
+++ b/src/parse/consume.rs
@@ -29,6 +29,7 @@
 use super::rule::{impls::RULE_FALLBACK, rules_for_token, Consumption};
 use super::token::ExtractedToken;
 use super::{ParseError, ParseErrorKind};
+use crate::text::FullText;
 use crate::tree::Element;
 
 /// Main function that consumes tokens to produce a single element, then returns.
@@ -36,6 +37,7 @@ pub fn consume<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     let ExtractedToken { token, slice, span } = extracted;
     let log = &log.new(slog_o!(
@@ -51,7 +53,7 @@ pub fn consume<'t, 'r>(
     for rule in rules_for_token(extracted) {
         info!(log, "Trying rule consumption for tokens"; "rule" => rule);
 
-        let consumption = rule.try_consume(log, extracted, remaining);
+        let consumption = rule.try_consume(log, extracted, remaining, full_text);
         if consumption.is_success() {
             debug!(log, "Rule matched, returning generated result"; "rule" => rule);
 

--- a/src/parse/macros.rs
+++ b/src/parse/macros.rs
@@ -1,0 +1,35 @@
+/*
+ * parse/macros.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// Return if `GenericConsumption::Failure`, else unwrap the success.
+///
+/// This is analogous to `try!` for the `GenericConsumption` enum.
+macro_rules! try_consume {
+    ($consumption:expr) => {
+        match $consumption {
+            GenericConsumption::Failure { error } => return GenericConsumption::err(error),
+            GenericConsumption::Success {
+                item,
+                remaining,
+                errors,
+            } => (item, remaining, errors),
+        }
+    };
+}

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -18,14 +18,17 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#[macro_use]
+mod macros;
+
+#[cfg(test)]
+mod test;
+
 mod consume;
 mod error;
 mod result;
 mod rule;
 mod token;
-
-#[cfg(test)]
-mod test;
 
 use self::consume::consume;
 use self::rule::Consumption;

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -82,7 +82,7 @@ where
         };
 
         match result {
-            ConsumptionResult::Success { element, remaining } => {
+            ConsumptionResult::Success { item, remaining } => {
                 debug!(log, "Tokens successfully consumed to produce element");
 
                 // Update remaining tokens
@@ -93,7 +93,7 @@ where
                 tokens = remaining;
 
                 // Add the new element to the list
-                output.push(element);
+                output.push(item);
             }
             ConsumptionResult::Failure => {
                 debug!(log, "Tokens unsuccessfully consumed, no element");

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -69,7 +69,7 @@ where
                 .split_first() //
                 .expect("Tokens list is empty");
 
-            consume(log, extracted, remaining)
+            consume(log, extracted, remaining, full_text)
         };
 
         match result {

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -29,6 +29,7 @@ mod test;
 
 use self::consume::consume;
 use self::rule::{Consumption, ConsumptionResult};
+use crate::tokenize::Tokenization;
 use crate::tree::SyntaxTree;
 
 pub use self::error::{ParseError, ParseErrorKind};
@@ -40,11 +41,16 @@ pub use self::token::{ExtractedToken, Token};
 /// This takes a list of `ExtractedToken` items produced by `tokenize()`.
 pub fn parse<'r, 't>(
     log: &slog::Logger,
-    mut tokens: &'r [ExtractedToken<'t>],
+    tokenization: &'r Tokenization<'t>,
 ) -> ParseResult<SyntaxTree<'t>>
 where
     'r: 't,
 {
+    // Set up variables
+    let mut tokens = tokenization.tokens();
+    let full_text = tokenization.full_text();
+    let mut output = ParseResult::default();
+
     // Logging setup
     let log = &log.new(slog_o!(
         "filename" => slog_filename!(),
@@ -53,10 +59,8 @@ where
         "tokens-len" => tokens.len(),
     ));
 
-    info!(log, "Running parser on tokens");
-
     // Run through tokens until finished
-    let mut output = ParseResult::default();
+    info!(log, "Running parser on tokens");
 
     while !tokens.is_empty() {
         // Consume tokens to produce the next element

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -35,19 +35,6 @@ pub use self::error::{ParseError, ParseErrorKind};
 pub use self::result::ParseResult;
 pub use self::token::{ExtractedToken, Token};
 
-/// Take an input string and produce a list of tokens for consumption by the parser.
-pub fn tokenize<'t>(log: &slog::Logger, text: &'t str) -> Vec<ExtractedToken<'t>> {
-    let log = &log.new(slog_o!(
-        "filename" => slog_filename!(),
-        "lineno" => slog_lineno!(),
-        "function" => "tokenize",
-        "text" => str!(text),
-    ));
-
-    info!(log, "Running lexer on text");
-    Token::extract_all(log, text)
-}
-
 /// Parse through the given tokens and produce an AST.
 ///
 /// This takes a list of `ExtractedToken` items produced by `tokenize()`.

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -48,8 +48,8 @@ impl<T> ParseResult<T> {
     }
 
     #[inline]
-    pub fn append_err(&mut self, error: ParseError) {
-        self.errors.push(error);
+    pub fn extend_errors(&mut self, errors: &[ParseError]) {
+        self.errors.extend_from_slice(errors);
     }
 
     pub fn join<U>(&mut self, other: ParseResult<U>) -> U {

--- a/src/parse/rule/collect.rs
+++ b/src/parse/rule/collect.rs
@@ -35,5 +35,20 @@ pub fn collect_until<'t, 'r>(
     invalid_tokens: &[Token],
     invalid_token_pairs: &[(Token, Token)],
 ) -> Consumption<'t, 'r> {
+    // Log collect_until() call
+    let log = &log.new(slog_o!(
+        "rule" => str!(rule.name()),
+        "token" => str!(extracted.token.name()),
+        "slice" => str!(extracted.slice),
+        "span-start" => extracted.span.start,
+        "span-end" => extracted.span.end,
+        "remaining-len" => remaining.len(),
+        "close-tokens" => format!("{:?}", close_tokens),
+        "invalid-tokens-len" => format!("{:?}", invalid_tokens),
+        "invalid-token-pairs-len" => format!("{:?}", invalid_token_pairs),
+    ));
+
+    info!(log, "Trying to collect tokens for rule {:?}", rule);
+
     todo!()
 }

--- a/src/parse/rule/collect.rs
+++ b/src/parse/rule/collect.rs
@@ -37,6 +37,7 @@ use std::fmt::Debug;
 /// * `log`
 /// * `extracted`
 /// * `remaining`
+/// * `full_text`
 ///
 /// The rule we're parsing for:
 /// * `rule`
@@ -61,9 +62,11 @@ use std::fmt::Debug;
 /// next rule in the list, or the text fallback.
 pub fn collect_until<'t, 'r, F, T>(
     log: &slog::Logger,
-    extracted: &'r ExtractedToken<'t>,
-    mut remaining: &'r [ExtractedToken<'t>],
-    full_text: FullText<'t>,
+    (extracted, mut remaining, full_text): (
+        &'r ExtractedToken<'t>,
+        &'r [ExtractedToken<'t>],
+        FullText<'t>,
+    ),
     rule: Rule,
     close_tokens: &[Token],
     invalid_tokens: &[Token],

--- a/src/parse/rule/collect.rs
+++ b/src/parse/rule/collect.rs
@@ -1,0 +1,39 @@
+/*
+ * parse/rule/collect.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use crate::parse::rule::{Consumption, ConsumptionResult, Rule};
+use crate::parse::token::{ExtractedToken, Token};
+
+/// Generic function to parse through tokens until conditions are met.
+///
+/// This is even more generic than `try_container`, as it doesn't produce
+/// a specific sub-element when done. It's more designed to remove the boilerplate
+/// of extracted token iteration by providing common notions and abilities.
+pub fn collect_until<'t, 'r>(
+    log: &slog::Logger,
+    extracted: &'r ExtractedToken<'t>,
+    mut remaining: &'r [ExtractedToken<'t>],
+    rule: Rule,
+    close_tokens: &[Token],
+    invalid_tokens: &[Token],
+    invalid_token_pairs: &[(Token, Token)],
+) -> Consumption<'t, 'r> {
+    todo!()
+}

--- a/src/parse/rule/collect.rs
+++ b/src/parse/rule/collect.rs
@@ -21,6 +21,7 @@
 use crate::parse::error::{ParseError, ParseErrorKind};
 use crate::parse::rule::{GenericConsumption, GenericConsumptionResult, Rule};
 use crate::parse::token::{ExtractedToken, Token};
+use crate::text::FullText;
 use std::fmt::Debug;
 
 /// Generic function to parse upcoming tokens until conditions are met.
@@ -62,6 +63,7 @@ pub fn collect_until<'t, 'r, F, T>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     mut remaining: &'r [ExtractedToken<'t>],
+    full_text: FullText<'t>,
     rule: Rule,
     close_tokens: &[Token],
     invalid_tokens: &[Token],
@@ -73,6 +75,7 @@ where
         &slog::Logger,
         &'r ExtractedToken<'t>,
         &'r [ExtractedToken<'t>],
+        FullText<'t>,
     ) -> GenericConsumption<'r, 't, T>,
     T: Debug,
 {
@@ -161,7 +164,7 @@ where
         }
 
         // Process token(s).
-        let consumption = process(log, new_extracted, new_remaining);
+        let consumption = process(log, new_extracted, new_remaining, full_text);
         match consumption.result {
             GenericConsumptionResult::Success {
                 item,

--- a/src/parse/rule/collect.rs
+++ b/src/parse/rule/collect.rs
@@ -60,7 +60,7 @@ use std::fmt::Debug;
 ///
 /// If the latter occurs, a `ParseError` is handed back and the parent will attempt the
 /// next rule in the list, or the text fallback.
-pub fn collect_until<'t, 'r, F, T>(
+pub fn try_collect<'t, 'r, F, T>(
     log: &slog::Logger,
     (extracted, mut remaining, full_text): (
         &'r ExtractedToken<'t>,

--- a/src/parse/rule/collect.rs
+++ b/src/parse/rule/collect.rs
@@ -18,15 +18,17 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::parse::rule::{Consumption, ConsumptionResult, Rule};
+use crate::parse::error::{ParseError, ParseErrorKind};
+use crate::parse::rule::{GenericConsumption, GenericConsumptionResult, Rule};
 use crate::parse::token::{ExtractedToken, Token};
+use std::fmt::Debug;
 
 /// Generic function to parse through tokens until conditions are met.
 ///
 /// This is even more generic than `try_container`, as it doesn't produce
 /// a specific sub-element when done. It's more designed to remove the boilerplate
 /// of extracted token iteration by providing common notions and abilities.
-pub fn collect_until<'t, 'r>(
+pub fn collect_until<'t, 'r, F, T>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     mut remaining: &'r [ExtractedToken<'t>],
@@ -34,7 +36,16 @@ pub fn collect_until<'t, 'r>(
     close_tokens: &[Token],
     invalid_tokens: &[Token],
     invalid_token_pairs: &[(Token, Token)],
-) -> Consumption<'t, 'r> {
+    mut process: F,
+) -> GenericConsumption<'r, 't, Vec<T>>
+where
+    F: FnMut(
+        &slog::Logger,
+        &'r ExtractedToken<'t>,
+        &'r [ExtractedToken<'t>],
+    ) -> GenericConsumption<'r, 't, T>,
+    T: Debug,
+{
     // Log collect_until() call
     let log = &log.new(slog_o!(
         "rule" => str!(rule.name()),
@@ -50,5 +61,114 @@ pub fn collect_until<'t, 'r>(
 
     info!(log, "Trying to collect tokens for rule {:?}", rule);
 
-    todo!()
+    let mut collected = Vec::new();
+    let mut prev_token = extracted.token;
+
+    while let Some((new_extracted, new_remaining)) = remaining.split_first() {
+        let current_token = new_extracted.token;
+
+        // Check previous and current tokens
+        let pair = &(prev_token, current_token);
+        if invalid_token_pairs.contains(&pair) {
+            debug!(
+                log,
+                "Found invalid (previous, current) token combination, failing rule";
+                "prev-token" => prev_token,
+                "current-token" => current_token,
+            );
+
+            return GenericConsumption::err(ParseError::new(
+                ParseErrorKind::RuleFailed,
+                rule,
+                new_extracted,
+            ));
+        }
+
+        // Update the state variables
+        //
+        // * "remaining" is updated in case we return
+        // * "prev_token" is updated as it's only checked above
+        remaining = new_remaining;
+        prev_token = current_token;
+
+        // "prev_token" should *not* be used underneath here.
+        // To enforce this, we shadow the variable name:
+        #[allow(unused_variables)]
+        let prev_token = ();
+
+        // Check current token to decide how to proceed.
+        //
+        // * End the container, return elements
+        // * Fail the container, invalid token
+        // * Continue the container, consume to make a new element
+
+        // See if the container has ended
+        if close_tokens.contains(&current_token) {
+            debug!(
+                log,
+                "Found ending token, returning collected elements";
+                "token" => current_token,
+                "collected" => format!("{:?}", collected),
+            );
+
+            return GenericConsumption::ok(collected, remaining);
+        }
+
+        // See if the container should be aborted
+        if invalid_tokens.contains(&current_token) {
+            debug!(
+                log,
+                "Found invalid token, aborting container attempt";
+                "token" => current_token,
+                "collected" => format!("{:?}", collected),
+            );
+
+            return GenericConsumption::err(ParseError::new(
+                ParseErrorKind::RuleFailed,
+                rule,
+                new_extracted,
+            ));
+        }
+
+        // Process token(s).
+        let consumption = process(log, new_extracted, new_remaining);
+        match consumption.result {
+            GenericConsumptionResult::Success {
+                element,
+                remaining: new_remaining,
+            } => {
+                debug!(
+                    log,
+                    "Adding newly produced item from token consumption";
+                    "item" => format!("{:?}", element),
+                    "remaining-len" => new_remaining.len(),
+                );
+
+                // Append new item
+                collected.push(element);
+
+                // Update token pointer
+                remaining = new_remaining;
+            }
+
+            GenericConsumptionResult::Failure => {
+                debug!(
+                    log,
+                    "Failed to produce item from consumption, bubbling up error",
+                );
+
+                return GenericConsumption::err(
+                    consumption
+                        .error
+                        .expect("Token consumption attemption did not produce an error"),
+                );
+            }
+        }
+    }
+
+    // If we've exhausted tokens but didn't find an ending token, we must abort.
+    //
+    // I don't think this will be terribly common, given that Token::InputEnd exists
+    // and terminates all token lists, but this logic needs to be here anyways.
+    GenericConsumption::err(ParseError::new(ParseErrorKind::EndOfInput, rule, extracted))
 }

--- a/src/parse/rule/collect.rs
+++ b/src/parse/rule/collect.rs
@@ -164,18 +164,18 @@ where
         let consumption = process(log, new_extracted, new_remaining);
         match consumption.result {
             GenericConsumptionResult::Success {
-                element,
+                item,
                 remaining: new_remaining,
             } => {
                 debug!(
                     log,
                     "Adding newly produced item from token consumption";
-                    "item" => format!("{:?}", element),
+                    "item" => format!("{:?}", item),
                     "remaining-len" => new_remaining.len(),
                 );
 
                 // Append new item
-                collected.push(element);
+                collected.push(item);
 
                 // Update token pointer
                 remaining = new_remaining;

--- a/src/parse/rule/collect.rs
+++ b/src/parse/rule/collect.rs
@@ -23,11 +23,41 @@ use crate::parse::rule::{GenericConsumption, GenericConsumptionResult, Rule};
 use crate::parse::token::{ExtractedToken, Token};
 use std::fmt::Debug;
 
-/// Generic function to parse through tokens until conditions are met.
+/// Generic function to parse upcoming tokens until conditions are met.
 ///
-/// This is even more generic than `try_container`, as it doesn't produce
-/// a specific sub-element when done. It's more designed to remove the boilerplate
-/// of extracted token iteration by providing common notions and abilities.
+/// Each handled token can then processed in some manner, in accordance
+/// to the passed closure.
+///
+/// The conditions for how to consume tokens are passed as arguments,
+/// which are explained below.
+///
+/// Normal arguments (from `try_consume_fn`):
+/// Obviously, the logger instance, and the current and upcoming tokens.
+/// * `log`
+/// * `extracted`
+/// * `remaining`
+///
+/// The rule we're parsing for:
+/// * `rule`
+///
+/// The tokens we should end iteration on:
+/// If one of these is the current token, we will return a consumption success.
+/// * `close_tokens`
+///
+/// The tokens we should abort on:
+/// If one of these is the current token, we will return a consumption failure.
+/// * `invalid_tokens`
+///
+/// The token pairs we should abort on:
+/// Each of these is a tuple in the form `(previous_token, current_token)`,
+/// if they ever are found adjacent during parsing, we will return a consumption failure.
+/// * `invalid_token_pairs`
+///
+/// This will proceed until a closing token is found, at which point the completed
+/// list of items will be returned, or until an abort is found.
+///
+/// If the latter occurs, a `ParseError` is handed back and the parent will attempt the
+/// next rule in the list, or the text fallback.
 pub fn collect_until<'t, 'r, F, T>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,

--- a/src/parse/rule/collect/container.rs
+++ b/src/parse/rule/collect/container.rs
@@ -71,7 +71,7 @@ pub fn try_container<'t, 'r>(
         "Current token does not match opener",
     );
 
-    // Actually iterate and collect
+    // Iterate and consume all the tokens
     let consumption = try_collect(
         log,
         (extracted, remaining, full_text),

--- a/src/parse/rule/collect/container.rs
+++ b/src/parse/rule/collect/container.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/container.rs
+ * parse/rule/collect/container.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -20,10 +20,7 @@
 
 //! Helper code to parse tokens out to generate recursive containers.
 
-use crate::parse::consume::consume;
-use crate::parse::rule::collect::try_collect;
-use crate::parse::rule::{Consumption, Rule};
-use crate::parse::token::{ExtractedToken, Token};
+use super::prelude::*;
 use crate::text::FullText;
 use crate::tree::{Container, ContainerType, Element};
 

--- a/src/parse/rule/collect/generic.rs
+++ b/src/parse/rule/collect/generic.rs
@@ -175,7 +175,10 @@ where
                     "Adding newly produced item from token consumption";
                     "item" => format!("{:?}", item),
                     "remaining-len" => new_remaining.len(),
+                    "has-error" => error.is_some(),
                 );
+
+                let error2 = &error;
 
                 // Append new item
                 collected.push(item);

--- a/src/parse/rule/collect/generic.rs
+++ b/src/parse/rule/collect/generic.rs
@@ -168,17 +168,14 @@ where
             GenericConsumption::Success {
                 item,
                 remaining: new_remaining,
-                error,
+                errors,
             } => {
                 debug!(
                     log,
                     "Adding newly produced item from token consumption";
                     "item" => format!("{:?}", item),
                     "remaining-len" => new_remaining.len(),
-                    "has-error" => error.is_some(),
                 );
-
-                let error2 = &error;
 
                 // Append new item
                 collected.push(item);

--- a/src/parse/rule/collect/generic.rs
+++ b/src/parse/rule/collect/generic.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/collect.rs
+ * parse/rule/collect/generic.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,10 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::parse::error::{ParseError, ParseErrorKind};
-use crate::parse::rule::{GenericConsumption, GenericConsumptionResult, Rule};
-use crate::parse::token::{ExtractedToken, Token};
-use crate::text::FullText;
+use super::prelude::*;
 use std::fmt::Debug;
 
 /// Generic function to parse upcoming tokens until conditions are met.

--- a/src/parse/rule/collect/generic.rs
+++ b/src/parse/rule/collect/generic.rs
@@ -95,6 +95,7 @@ where
     info!(log, "Trying to collect tokens for rule {:?}", rule);
 
     let mut collected = Vec::new();
+    let mut all_errors = Vec::new();
     let mut prev_token = extracted.token;
 
     while let Some((new_extracted, new_remaining)) = remaining.split_first() {
@@ -144,7 +145,7 @@ where
                 "collected" => format!("{:?}", collected),
             );
 
-            return GenericConsumption::ok(collected, remaining);
+            return GenericConsumption::warn(collected, remaining, all_errors);
         }
 
         // See if the container should be aborted
@@ -182,6 +183,9 @@ where
 
                 // Update token pointer
                 remaining = new_remaining;
+
+                // Append new errors
+                all_errors.extend_from_slice(&errors)
             }
 
             GenericConsumption::Failure { error } => {

--- a/src/parse/rule/collect/generic.rs
+++ b/src/parse/rule/collect/generic.rs
@@ -164,11 +164,11 @@ where
         }
 
         // Process token(s).
-        let consumption = process(log, new_extracted, new_remaining, full_text);
-        match consumption.result {
-            GenericConsumptionResult::Success {
+        match process(log, new_extracted, new_remaining, full_text) {
+            GenericConsumption::Success {
                 item,
                 remaining: new_remaining,
+                error,
             } => {
                 debug!(
                     log,
@@ -184,17 +184,13 @@ where
                 remaining = new_remaining;
             }
 
-            GenericConsumptionResult::Failure => {
+            GenericConsumption::Failure { error } => {
                 debug!(
                     log,
                     "Failed to produce item from consumption, bubbling up error",
                 );
 
-                return GenericConsumption::err(
-                    consumption
-                        .error
-                        .expect("Token consumption attemption did not produce an error"),
-                );
+                return GenericConsumption::err(error);
             }
         }
     }

--- a/src/parse/rule/collect/merge.rs
+++ b/src/parse/rule/collect/merge.rs
@@ -1,0 +1,60 @@
+/*
+ * parse/rule/collect/merge.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+
+/// Generic function to consume all tokens into a single string slice.
+///
+/// This is a subset of the functionality provided by `try_collect`,
+/// as it specifically gathers all the extracted tokens into a string slice,
+/// rather than considering them as special elements.
+pub fn try_merge<'t, 'r>(
+    log: &slog::Logger,
+    (extracted, remaining, full_text): (
+        &'r ExtractedToken<'t>,
+        &'r [ExtractedToken<'t>],
+        FullText<'t>,
+    ),
+    rule: Rule,
+    close_tokens: &[Token],
+    invalid_tokens: &[Token],
+    invalid_token_pairs: &[(Token, Token)],
+) -> GenericConsumption<'t, 'r, &'t str> {
+    // Log try_merge() call
+    info!(log, "Trying to consume tokens to merge into a single string");
+
+    let tokens = try_collect(
+        log,
+        (extracted, remaining, full_text),
+        rule,
+        close_tokens,
+        invalid_tokens,
+        invalid_token_pairs,
+        |log, extracted, remaining, _full_text| {
+            trace!(log, "Ingesting token in string merge");
+
+            GenericConsumption::ok(extracted, remaining)
+        },
+    );
+
+    println!("tokens {:#?}", tokens);
+
+    todo!()
+}

--- a/src/parse/rule/collect/mod.rs
+++ b/src/parse/rule/collect/mod.rs
@@ -24,12 +24,12 @@
 //! some action over tokens, finishing or abortion when it reaches certain tokens.
 
 mod prelude {
+    pub use super::try_collect;
     pub use crate::parse::consume::consume;
     pub use crate::parse::error::{ParseError, ParseErrorKind};
     pub use crate::parse::rule::{Consumption, GenericConsumption, GenericConsumptionResult, Rule};
     pub use crate::parse::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
-    pub use super::try_collect;
 }
 
 mod container;

--- a/src/parse/rule/collect/mod.rs
+++ b/src/parse/rule/collect/mod.rs
@@ -27,7 +27,7 @@ mod prelude {
     pub use super::try_collect;
     pub use crate::parse::consume::consume;
     pub use crate::parse::error::{ParseError, ParseErrorKind};
-    pub use crate::parse::rule::{Consumption, GenericConsumption, GenericConsumptionResult, Rule};
+    pub use crate::parse::rule::{Consumption, GenericConsumption, Rule};
     pub use crate::parse::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
 }

--- a/src/parse/rule/collect/mod.rs
+++ b/src/parse/rule/collect/mod.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/mod.rs
+ * parse/rule/collect/mod.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,38 +18,22 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+//! Module which contains functions to iterate through tokens and output according to rules.
+//!
+//! The main function here is `try_collect()`, which is a generic procedure to perform
+//! some action over tokens, finishing or abortion when it reaches certain tokens.
+
 mod prelude {
+    pub use super::try_collect;
     pub use crate::parse::consume::consume;
     pub use crate::parse::error::{ParseError, ParseErrorKind};
-    pub use crate::parse::rule::collect::*;
-    pub use crate::parse::rule::{Consumption, ConsumptionResult, Rule, TryConsumeFn};
+    pub use crate::parse::rule::{Consumption, GenericConsumption, GenericConsumptionResult, Rule};
     pub use crate::parse::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
-    pub use crate::tree::{Container, ContainerType, Element};
 }
 
-mod bold;
-mod color;
-mod comment;
-mod email;
-mod fallback;
-mod italics;
-mod line_break;
-mod null;
-mod raw;
-mod text;
-mod todo;
-mod url;
+mod container;
+mod generic;
 
-pub use self::bold::RULE_BOLD;
-pub use self::color::RULE_COLOR;
-pub use self::comment::RULE_COMMENT;
-pub use self::email::RULE_EMAIL;
-pub use self::fallback::RULE_FALLBACK;
-pub use self::italics::RULE_ITALICS;
-pub use self::line_break::RULE_LINE_BREAK;
-pub use self::null::RULE_NULL;
-pub use self::raw::RULE_RAW;
-pub use self::text::RULE_TEXT;
-pub use self::todo::RULE_TODO;
-pub use self::url::RULE_URL;
+pub use self::container::try_container;
+pub use self::generic::try_collect;

--- a/src/parse/rule/collect/mod.rs
+++ b/src/parse/rule/collect/mod.rs
@@ -24,16 +24,18 @@
 //! some action over tokens, finishing or abortion when it reaches certain tokens.
 
 mod prelude {
-    pub use super::try_collect;
     pub use crate::parse::consume::consume;
     pub use crate::parse::error::{ParseError, ParseErrorKind};
     pub use crate::parse::rule::{Consumption, GenericConsumption, GenericConsumptionResult, Rule};
     pub use crate::parse::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
+    pub use super::try_collect;
 }
 
 mod container;
 mod generic;
+mod merge;
 
 pub use self::container::try_container;
 pub use self::generic::try_collect;
+pub use self::merge::try_merge;

--- a/src/parse/rule/container.rs
+++ b/src/parse/rule/container.rs
@@ -21,8 +21,7 @@
 //! Helper code to parse tokens out to generate recursive containers.
 
 use crate::parse::consume::consume;
-use crate::parse::error::{ParseError, ParseErrorKind};
-use crate::parse::rule::{collect_until, Consumption, ConsumptionResult, Rule};
+use crate::parse::rule::{collect_until, Consumption, Rule};
 use crate::parse::token::{ExtractedToken, Token};
 use crate::tree::{Container, ContainerType, Element};
 
@@ -47,7 +46,7 @@ use crate::tree::{Container, ContainerType, Element};
 pub fn try_container<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
-    mut remaining: &'r [ExtractedToken<'t>],
+    remaining: &'r [ExtractedToken<'t>],
     (rule, container_type): (Rule, ContainerType),
     (open_token, close_token): (Token, Token),
     invalid_tokens: &[Token],

--- a/src/parse/rule/container.rs
+++ b/src/parse/rule/container.rs
@@ -21,7 +21,8 @@
 //! Helper code to parse tokens out to generate recursive containers.
 
 use crate::parse::consume::consume;
-use crate::parse::rule::{collect_until, Consumption, Rule};
+use crate::parse::rule::collect::collect_until;
+use crate::parse::rule::{Consumption, Rule};
 use crate::parse::token::{ExtractedToken, Token};
 use crate::tree::{Container, ContainerType, Element};
 

--- a/src/parse/rule/container.rs
+++ b/src/parse/rule/container.rs
@@ -21,7 +21,7 @@
 //! Helper code to parse tokens out to generate recursive containers.
 
 use crate::parse::consume::consume;
-use crate::parse::rule::collect::collect_until;
+use crate::parse::rule::collect::try_collect;
 use crate::parse::rule::{Consumption, Rule};
 use crate::parse::token::{ExtractedToken, Token};
 use crate::text::FullText;
@@ -29,7 +29,7 @@ use crate::tree::{Container, ContainerType, Element};
 
 /// Generic function to consume tokens into a container.
 ///
-/// This is a subset of the functionality provided by `collect_until`,
+/// This is a subset of the functionality provided by `try_collect`,
 /// as it builds `Container`s specifically rather, but still permits
 /// passing arguments to specify behavior and reduce boilerplate.
 ///
@@ -75,7 +75,7 @@ pub fn try_container<'t, 'r>(
     );
 
     // Actually iterate and collect
-    let consumption = collect_until(
+    let consumption = try_collect(
         log,
         (extracted, remaining, full_text),
         rule,

--- a/src/parse/rule/container.rs
+++ b/src/parse/rule/container.rs
@@ -24,6 +24,7 @@ use crate::parse::consume::consume;
 use crate::parse::rule::collect::collect_until;
 use crate::parse::rule::{Consumption, Rule};
 use crate::parse::token::{ExtractedToken, Token};
+use crate::text::FullText;
 use crate::tree::{Container, ContainerType, Element};
 
 /// Generic function to consume tokens into a container.
@@ -48,6 +49,7 @@ pub fn try_container<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    full_text: FullText<'t>,
     (rule, container_type): (Rule, ContainerType<'t>),
     (open_token, close_token): (Token, Token),
     invalid_tokens: &[Token],
@@ -75,6 +77,7 @@ pub fn try_container<'t, 'r>(
         log,
         extracted,
         remaining,
+        full_text,
         rule,
         &[close_token],
         invalid_tokens,

--- a/src/parse/rule/container.rs
+++ b/src/parse/rule/container.rs
@@ -193,7 +193,7 @@ pub fn try_container<'t, 'r>(
             ConsumptionResult::Failure => {
                 debug!(
                     log,
-                    "Failed to produce token from consumption, bubbling up error",
+                    "Failed to produce item from consumption, bubbling up error",
                 );
 
                 return consumption;
@@ -205,5 +205,5 @@ pub fn try_container<'t, 'r>(
     //
     // I don't think this will be terribly common, given that Token::InputEnd exists
     // and terminates all token lists, but this logic needs to be here anyways.
-    Consumption::err(ParseError::new(ParseErrorKind::RuleFailed, rule, extracted))
+    Consumption::err(ParseError::new(ParseErrorKind::EndOfInput, rule, extracted))
 }

--- a/src/parse/rule/container.rs
+++ b/src/parse/rule/container.rs
@@ -22,23 +22,19 @@
 
 use crate::parse::consume::consume;
 use crate::parse::error::{ParseError, ParseErrorKind};
-use crate::parse::rule::{Consumption, ConsumptionResult, Rule};
+use crate::parse::rule::{collect_until, Consumption, ConsumptionResult, Rule};
 use crate::parse::token::{ExtractedToken, Token};
 use crate::tree::{Container, ContainerType, Element};
 
-/// Generic function to parse upcoming tokens into a container.
+/// Generic function to consume tokens into a container.
 ///
-/// The conditions for how to consume tokens are passed as arguments,
-/// which are explained below.
+/// This is a subset of the functionality provided by `collect_until`,
+/// as it builds `Container`s specifically rather, but still permits
+/// passing arguments to specify behavior and reduce boilerplate.
 ///
-/// Normal arguments (from `try_consume_fn`):
-/// Obviously, the logger instance, and the current and upcoming tokens.
-/// * `log`
-/// * `extracted`
-/// * `remaining`
-///
-/// The rule we're parsing for:
-/// * `rule`
+/// The arguments which differ from `collect_until` are listed:
+/// See that function for full documentation, as the call here
+/// mostly wraps it.
 ///
 /// The kind of container we're building:
 /// Must match the parse rule.
@@ -48,20 +44,6 @@ use crate::tree::{Container, ContainerType, Element};
 /// This will perform an assertion that the current token matches the opening type.
 /// * `open_token`
 /// * `close_token`
-///
-/// The tokens we should abort the container on:
-/// If one of these is the current token, we will return a consumption failure.
-/// * `invalid_tokens`
-///
-/// The token pairs we should abort the container on:
-/// Each of these is a tuple in the form `(previous_token, current_token)`,
-/// if they ever are found adjacent during parsing, we will return a consumption failure.
-/// * `invalid_token_pairs`
-///
-/// This will proceed until the closing token is found, at which point the completed
-/// container element will be returned, or until an abort is found.
-/// If the latter occurs, a `ParseError` is handed back and the parent will attempt the
-/// next rule in the list, or the text fallback.
 pub fn try_container<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
@@ -74,16 +56,7 @@ pub fn try_container<'t, 'r>(
     // Log try_container() call
     let log = &log.new(slog_o!(
         "container-type" => str!(container_type.name()),
-        "rule" => str!(rule.name()),
-        "token" => str!(extracted.token.name()),
-        "slice" => str!(extracted.slice),
-        "span-start" => extracted.span.start,
-        "span-end" => extracted.span.end,
-        "remaining-len" => remaining.len(),
         "open-token" => open_token,
-        "close-token" => close_token,
-        "invalid-tokens-len" => invalid_tokens.len(),
-        "invalid-token-pairs-len" => invalid_token_pairs.len(),
     ));
 
     info!(
@@ -97,113 +70,23 @@ pub fn try_container<'t, 'r>(
         "Current token does not match opener",
     );
 
-    // Begin building up the child elements
-    let mut elements = Vec::new();
-    let mut prev_token = extracted.token;
+    // Actually iterate and collect
+    let consumption = collect_until(
+        log,
+        extracted,
+        remaining,
+        rule,
+        &[close_token],
+        invalid_tokens,
+        invalid_token_pairs,
+        consume,
+    );
 
-    while let Some((new_extracted, new_remaining)) = remaining.split_first() {
-        let current_token = new_extracted.token;
+    // Package into a container
+    consumption.map(|elements| {
+        let container = Container::new(container_type, elements);
+        let element = Element::Container(container);
 
-        // Check previous and current tokens
-        let pair = &(prev_token, current_token);
-        if invalid_token_pairs.contains(&pair) {
-            debug!(
-                log,
-                "Found invalid (previous, current) token combination, failing rule";
-                "prev-token" => prev_token,
-                "current-token" => current_token,
-            );
-
-            return Consumption::err(ParseError::new(
-                ParseErrorKind::RuleFailed,
-                rule,
-                new_extracted,
-            ));
-        }
-
-        // Update the state variables
-        //
-        // * "remaining" is updated in case we return
-        // * "prev_token" is updated as it's only checked above
-        remaining = new_remaining;
-        prev_token = current_token;
-
-        // "prev_token" should *not* be used underneath here.
-        // To enforce this, we shadow the variable name:
-        #[allow(unused_variables)]
-        let prev_token = ();
-
-        // Check current token to decide how to proceed.
-        //
-        // * End the container, return elements
-        // * Fail the container, invalid token
-        // * Continue the container, consume to make a new element
-
-        // See if the container has ended
-        if current_token == close_token {
-            debug!(
-                log,
-                "Found ending token, returning collected elements";
-                "elements-len" => elements.len(),
-            );
-
-            let container = Container::new(container_type, elements);
-            let element = Element::Container(container);
-
-            return Consumption::ok(element, remaining);
-        }
-
-        // See if the container should be aborted
-        if invalid_tokens.contains(&current_token) {
-            debug!(
-                log,
-                "Found invalid token, aborting container attempt";
-                "token" => current_token,
-                "elements-len" => elements.len(),
-            );
-
-            return Consumption::err(ParseError::new(
-                ParseErrorKind::RuleFailed,
-                rule,
-                new_extracted,
-            ));
-        }
-
-        // Consume tokens to produce a new element
-        let consumption = consume(log, new_extracted, new_remaining);
-        match consumption.result {
-            ConsumptionResult::Success {
-                element,
-                remaining: new_remaining,
-            } => {
-                debug!(
-                    log,
-                    "Adding newly produced element from token consumption";
-                    "element" => element.name(),
-                    "remaining-len" => new_remaining.len(),
-                );
-
-                // Add new element to container
-                elements.push(element);
-
-                // Update token pointer
-                remaining = new_remaining;
-            }
-
-            ConsumptionResult::Failure => {
-                debug!(
-                    log,
-                    "Failed to produce item from consumption, bubbling up error",
-                );
-
-                return consumption;
-            }
-        }
-    }
-
-    // If we've exhausted tokens but didn't find an ending token, we must abort.
-    //
-    // I don't think this will be terribly common, given that Token::InputEnd exists
-    // and terminates all token lists, but this logic needs to be here anyways.
-    Consumption::err(ParseError::new(ParseErrorKind::EndOfInput, rule, extracted))
+        element
+    })
 }

--- a/src/parse/rule/container.rs
+++ b/src/parse/rule/container.rs
@@ -47,9 +47,11 @@ use crate::tree::{Container, ContainerType, Element};
 /// * `close_token`
 pub fn try_container<'t, 'r>(
     log: &slog::Logger,
-    extracted: &'r ExtractedToken<'t>,
-    remaining: &'r [ExtractedToken<'t>],
-    full_text: FullText<'t>,
+    (extracted, remaining, full_text): (
+        &'r ExtractedToken<'t>,
+        &'r [ExtractedToken<'t>],
+        FullText<'t>,
+    ),
     (rule, container_type): (Rule, ContainerType<'t>),
     (open_token, close_token): (Token, Token),
     invalid_tokens: &[Token],
@@ -75,9 +77,7 @@ pub fn try_container<'t, 'r>(
     // Actually iterate and collect
     let consumption = collect_until(
         log,
-        extracted,
-        remaining,
-        full_text,
+        (extracted, remaining, full_text),
         rule,
         &[close_token],
         invalid_tokens,

--- a/src/parse/rule/container.rs
+++ b/src/parse/rule/container.rs
@@ -86,10 +86,5 @@ pub fn try_container<'t, 'r>(
     );
 
     // Package into a container
-    consumption.map(|elements| {
-        let container = Container::new(container_type, elements);
-        let element = Element::Container(container);
-
-        element
-    })
+    consumption.map(|elements| Element::Container(Container::new(container_type, elements)))
 }

--- a/src/parse/rule/container.rs
+++ b/src/parse/rule/container.rs
@@ -48,7 +48,7 @@ pub fn try_container<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
-    (rule, container_type): (Rule, ContainerType),
+    (rule, container_type): (Rule, ContainerType<'t>),
     (open_token, close_token): (Token, Token),
     invalid_tokens: &[Token],
     invalid_token_pairs: &[(Token, Token)],

--- a/src/parse/rule/impls/bold.rs
+++ b/src/parse/rule/impls/bold.rs
@@ -29,6 +29,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Trying to create bold container");
 
@@ -36,6 +37,7 @@ fn try_consume_fn<'t, 'r>(
         log,
         extracted,
         remaining,
+        full_text,
         (RULE_BOLD, ContainerType::Bold),
         (Token::Bold, Token::Bold),
         &[Token::ParagraphBreak, Token::InputEnd],

--- a/src/parse/rule/impls/bold.rs
+++ b/src/parse/rule/impls/bold.rs
@@ -35,9 +35,7 @@ fn try_consume_fn<'t, 'r>(
 
     try_container(
         log,
-        extracted,
-        remaining,
-        full_text,
+        (extracted, remaining, full_text),
         (RULE_BOLD, ContainerType::Bold),
         (Token::Bold, Token::Bold),
         &[Token::ParagraphBreak, Token::InputEnd],

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -43,36 +43,29 @@ fn try_consume_fn<'t, 'r>(
     // ## [color-style] | [text to be colored] ##
 
     // Gather the color name until the separator
-    let _color = {
-        try_merge(
-            log,
-            (extracted, remaining, full_text),
-            RULE_COLOR,
-            &[Token::Pipe],
-            &[Token::ParagraphBreak, Token::LineBreak, Token::InputEnd],
-            &[],
-        )
+    let GenericConsumption { result, error } = try_merge(
+        log,
+        (extracted, remaining, full_text),
+        RULE_COLOR,
+        &[Token::Pipe],
+        &[Token::ParagraphBreak, Token::LineBreak, Token::InputEnd],
+        &[],
+    );
+
+    let (color, remaining) = match result {
+        GenericConsumptionResult::Success { item, remaining } => (item, remaining),
+        GenericConsumptionResult::Failure => return GenericConsumption::err(error.unwrap()),
     };
 
-    todo!()
-}
+    debug!(log, "Retrieved color descriptor, now building container"; "color" => color);
 
-/*
-pub fn collect_until<'t, 'r, F, T>(
-    log: &slog::Logger,
-    extracted: &'r ExtractedToken<'t>,
-    mut remaining: &'r [ExtractedToken<'t>],
-    rule: Rule,
-    close_tokens: &[Token],
-    invalid_tokens: &[Token],
-    invalid_token_pairs: &[(Token, Token)],
-    mut process: F,
-) -> GenericConsumption<'r, 't, Vec<T>>
-where
-    F: FnMut(
-        &slog::Logger,
-        &'r ExtractedToken<'t>,
-        &'r [ExtractedToken<'t>],
-    ) -> GenericConsumption<'r, 't, T>,
-    T: Debug,
-*/
+    // Build color container
+    try_container(
+        log,
+        (extracted, remaining, full_text),
+        (RULE_COLOR, ContainerType::Color(color)),
+        (Token::Pipe, Token::Color),
+        &[Token::ParagraphBreak, Token::InputEnd],
+        &[],
+    )
+}

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -53,22 +53,19 @@ fn try_consume_fn<'t, 'r>(
     );
 
     // Return if failure
-    let (color, remaining, error) = match consumption {
+    let (color, remaining, errors) = match consumption {
         GenericConsumption::Failure { error } => return GenericConsumption::err(error),
         GenericConsumption::Success {
             item,
             remaining,
-            error,
-        } => (item, remaining, error),
+            errors,
+        } => (item, remaining, errors),
     };
-
-    let error2 = &error;
 
     debug!(
         log,
         "Retrieved color descriptor, now building container";
         "color" => color,
-        "has-error" => error.is_some(),
     );
 
     // Build color container

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -61,6 +61,18 @@ fn try_consume_fn<'t, 'r>(
         "color" => color,
     );
 
+    // Extract next token to resume parsing
+    let (extracted, remaining) = match remaining.split_first() {
+        Some(split) => split,
+        None => {
+            return Consumption::err(ParseError::new(
+                ParseErrorKind::EndOfInput,
+                RULE_COLOR,
+                extracted,
+            ))
+        }
+    };
+
     // Build color container
     let consumption = try_container(
         log,

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -1,0 +1,53 @@
+/*
+ * parse/rule/impls/color.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+
+pub const RULE_COLOR: Rule = Rule {
+    name: "color",
+    try_consume_fn,
+};
+
+fn try_consume_fn<'t, 'r>(
+    log: &slog::Logger,
+    extracted: &'r ExtractedToken<'t>,
+    remaining: &'r [ExtractedToken<'t>],
+) -> Consumption<'t, 'r> {
+    debug!(log, "Trying to create color container");
+
+    assert_eq!(extracted.token, Token::Color, "Current token isn't '##'");
+
+    /*
+    try_container(
+        log,
+        extracted,
+        remaining,
+        (RULE_BOLD, ContainerType::Bold),
+        (Token::Bold, Token::Bold),
+        &[Token::ParagraphBreak, Token::InputEnd],
+        &[
+            (Token::Bold, Token::Whitespace),
+            (Token::Whitespace, Token::Bold),
+        ],
+    )
+    */
+
+    todo!()
+}

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -53,25 +53,30 @@ fn try_consume_fn<'t, 'r>(
     );
 
     // Return if failure
-    let (color, remaining, mut all_errors) = try_consume!(consumption);
+    let (color, new_remaining, mut all_errors) = try_consume!(consumption);
+
+    // Get last token as the current, "extracted" value.
+    // try_container() expects the first token to be signifier, not content
+    // In this case, it would be the "|" between color and contents.
+    //
+    // So we look for the pipe token. Kind of hacky, better than producing
+    // a fake ExtractedToken or adding conditional logic to try_container().
+    let (extracted, remaining) = {
+        // Find the Token::Pipe from the old token pointer.
+        // It must exist, as we've already crossed it.
+        let extracted = remaining
+            .iter()
+            .find(|e| e.token == Token::Pipe)
+            .expect("Pipe not found after try_merge() succeeded");
+
+        (extracted, new_remaining)
+    };
 
     debug!(
         log,
         "Retrieved color descriptor, now building container";
         "color" => color,
     );
-
-    // Extract next token to resume parsing
-    let (extracted, remaining) = match remaining.split_first() {
-        Some(split) => split,
-        None => {
-            return Consumption::err(ParseError::new(
-                ParseErrorKind::EndOfInput,
-                RULE_COLOR,
-                extracted,
-            ))
-        }
-    };
 
     // Build color container
     let consumption = try_container(

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -43,7 +43,7 @@ fn try_consume_fn<'t, 'r>(
     // ## [color-style] | [text to be colored] ##
 
     // Gather the color name until the separator
-    let GenericConsumption { result, error } = try_merge(
+    let consumption = try_merge(
         log,
         (extracted, remaining, full_text),
         RULE_COLOR,
@@ -52,12 +52,24 @@ fn try_consume_fn<'t, 'r>(
         &[],
     );
 
-    let (color, remaining) = match result {
-        GenericConsumptionResult::Success { item, remaining } => (item, remaining),
-        GenericConsumptionResult::Failure => return GenericConsumption::err(error.unwrap()),
+    // Return if failure
+    let (color, remaining, error) = match consumption {
+        GenericConsumption::Failure { error } => return GenericConsumption::err(error),
+        GenericConsumption::Success {
+            item,
+            remaining,
+            error,
+        } => (item, remaining, error),
     };
 
-    debug!(log, "Retrieved color descriptor, now building container"; "color" => color);
+    let error2 = &error;
+
+    debug!(
+        log,
+        "Retrieved color descriptor, now building container";
+        "color" => color,
+        "has-error" => error.is_some(),
+    );
 
     // Build color container
     try_container(

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -29,26 +29,50 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
-    _full_text: FullText<'t>,
+    full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Trying to create color container");
 
-    assert_eq!(extracted.token, Token::Color, "Current token isn't '##'");
+    assert_eq!(
+        extracted.token,
+        Token::Color,
+        "Current token isn't color marker",
+    );
 
-    /*
-    try_container(
-        log,
-        extracted,
-        remaining,
-        (RULE_BOLD, ContainerType::Bold),
-        (Token::Bold, Token::Bold),
-        &[Token::ParagraphBreak, Token::InputEnd],
-        &[
-            (Token::Bold, Token::Whitespace),
-            (Token::Whitespace, Token::Bold),
-        ],
-    )
-    */
+    // The pattern for color is:
+    // ## [color-style] | [text to be colored] ##
+
+    // Gather the color name until the separator
+    let _color = {
+        try_merge(
+            log,
+            (extracted, remaining, full_text),
+            RULE_COLOR,
+            &[Token::Pipe],
+            &[Token::ParagraphBreak, Token::LineBreak, Token::InputEnd],
+            &[],
+        )
+    };
 
     todo!()
 }
+
+/*
+pub fn collect_until<'t, 'r, F, T>(
+    log: &slog::Logger,
+    extracted: &'r ExtractedToken<'t>,
+    mut remaining: &'r [ExtractedToken<'t>],
+    rule: Rule,
+    close_tokens: &[Token],
+    invalid_tokens: &[Token],
+    invalid_token_pairs: &[(Token, Token)],
+    mut process: F,
+) -> GenericConsumption<'r, 't, Vec<T>>
+where
+    F: FnMut(
+        &slog::Logger,
+        &'r ExtractedToken<'t>,
+        &'r [ExtractedToken<'t>],
+    ) -> GenericConsumption<'r, 't, T>,
+    T: Debug,
+*/

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -29,6 +29,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    _full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Trying to create color container");
 

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -53,14 +53,7 @@ fn try_consume_fn<'t, 'r>(
     );
 
     // Return if failure
-    let (color, remaining, mut all_errors) = match consumption {
-        GenericConsumption::Failure { error } => return GenericConsumption::err(error),
-        GenericConsumption::Success {
-            item,
-            remaining,
-            errors,
-        } => (item, remaining, errors),
-    };
+    let (color, remaining, mut all_errors) = try_consume!(consumption);
 
     debug!(
         log,
@@ -79,18 +72,11 @@ fn try_consume_fn<'t, 'r>(
     );
 
     // Append errors, or return if failure
-    match consumption {
-        GenericConsumption::Failure { error } => GenericConsumption::err(error),
-        GenericConsumption::Success {
-            item,
-            remaining,
-            mut errors,
-        } => {
-            // Add on other errors
-            all_errors.append(&mut errors);
+    let (item, remaining, mut errors) = try_consume!(consumption);
 
-            // Return consumption
-            GenericConsumption::warn(item, remaining, all_errors)
-        }
-    }
+    // Add on new errors
+    all_errors.append(&mut errors);
+
+    // Return result
+    GenericConsumption::warn(item, remaining, all_errors)
 }

--- a/src/parse/rule/impls/comment.rs
+++ b/src/parse/rule/impls/comment.rs
@@ -29,6 +29,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     mut remaining: &'r [ExtractedToken<'t>],
+    _full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Consuming tokens until end of comment");
 

--- a/src/parse/rule/impls/email.rs
+++ b/src/parse/rule/impls/email.rs
@@ -29,6 +29,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    _full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Consuming token as an email");
 

--- a/src/parse/rule/impls/fallback.rs
+++ b/src/parse/rule/impls/fallback.rs
@@ -37,6 +37,7 @@ fn try_consume_fn<'t, 'r>(
     _: &slog::Logger,
     _: &'r ExtractedToken<'t>,
     _: &'r [ExtractedToken<'t>],
+    _: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     panic!("Manual fallback rule should not be executed directly!")
 }

--- a/src/parse/rule/impls/italics.rs
+++ b/src/parse/rule/impls/italics.rs
@@ -35,9 +35,7 @@ fn try_consume_fn<'t, 'r>(
 
     try_container(
         log,
-        extracted,
-        remaining,
-        full_text,
+        (extracted, remaining, full_text),
         (RULE_ITALICS, ContainerType::Italics),
         (Token::Italics, Token::Italics),
         &[Token::ParagraphBreak, Token::InputEnd],

--- a/src/parse/rule/impls/italics.rs
+++ b/src/parse/rule/impls/italics.rs
@@ -29,6 +29,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Trying to create italics container");
 
@@ -36,6 +37,7 @@ fn try_consume_fn<'t, 'r>(
         log,
         extracted,
         remaining,
+        full_text,
         (RULE_ITALICS, ContainerType::Italics),
         (Token::Italics, Token::Italics),
         &[Token::ParagraphBreak, Token::InputEnd],

--- a/src/parse/rule/impls/line_break.rs
+++ b/src/parse/rule/impls/line_break.rs
@@ -29,6 +29,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     _extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    _full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Consuming token as line break");
 

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -22,7 +22,10 @@ mod prelude {
     pub use crate::parse::consume::consume;
     pub use crate::parse::error::{ParseError, ParseErrorKind};
     pub use crate::parse::rule::collect::*;
-    pub use crate::parse::rule::{Consumption, ConsumptionResult, Rule, TryConsumeFn};
+    pub use crate::parse::rule::{
+        Consumption, ConsumptionResult, GenericConsumption, GenericConsumptionResult, Rule,
+        TryConsumeFn,
+    };
     pub use crate::parse::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
     pub use crate::tree::{Container, ContainerType, Element};

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -25,6 +25,7 @@ mod prelude {
     pub use crate::parse::rule::container::try_container;
     pub use crate::parse::rule::{Consumption, ConsumptionResult, Rule, TryConsumeFn};
     pub use crate::parse::token::{ExtractedToken, Token};
+    pub use crate::text::FullText;
     pub use crate::tree::{Container, ContainerType, Element};
 }
 

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -21,6 +21,7 @@
 mod prelude {
     pub use crate::parse::consume::consume;
     pub use crate::parse::error::{ParseError, ParseErrorKind};
+    pub use crate::parse::rule::collect::collect_until;
     pub use crate::parse::rule::container::try_container;
     pub use crate::parse::rule::{Consumption, ConsumptionResult, Rule, TryConsumeFn};
     pub use crate::parse::token::{ExtractedToken, Token};

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -21,7 +21,7 @@
 mod prelude {
     pub use crate::parse::consume::consume;
     pub use crate::parse::error::{ParseError, ParseErrorKind};
-    pub use crate::parse::rule::collect::collect_until;
+    pub use crate::parse::rule::collect::try_collect;
     pub use crate::parse::rule::container::try_container;
     pub use crate::parse::rule::{Consumption, ConsumptionResult, Rule, TryConsumeFn};
     pub use crate::parse::token::{ExtractedToken, Token};

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -28,6 +28,7 @@ mod prelude {
 }
 
 mod bold;
+mod color;
 mod comment;
 mod email;
 mod fallback;
@@ -40,6 +41,7 @@ mod todo;
 mod url;
 
 pub use self::bold::RULE_BOLD;
+pub use self::color::RULE_COLOR;
 pub use self::comment::RULE_COMMENT;
 pub use self::email::RULE_EMAIL;
 pub use self::fallback::RULE_FALLBACK;

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -22,10 +22,7 @@ mod prelude {
     pub use crate::parse::consume::consume;
     pub use crate::parse::error::{ParseError, ParseErrorKind};
     pub use crate::parse::rule::collect::*;
-    pub use crate::parse::rule::{
-        Consumption, ConsumptionResult, GenericConsumption, GenericConsumptionResult, Rule,
-        TryConsumeFn,
-    };
+    pub use crate::parse::rule::{Consumption, GenericConsumption, Rule, TryConsumeFn};
     pub use crate::parse::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
     pub use crate::tree::{Container, ContainerType, Element};

--- a/src/parse/rule/impls/null.rs
+++ b/src/parse/rule/impls/null.rs
@@ -29,6 +29,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     _extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    _full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Consuming token and outputting null element");
 

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -152,7 +152,7 @@ fn try_consume_fn<'t, 'r>(
                 if *token == ending_token {
                     trace!(log, "Reached end of raw, returning");
 
-                    let slice = full_text.slice(start, end);
+                    let slice = full_text.slice(log, start, end);
                     let element = Element::Raw(slice);
                     return Consumption::ok(element, new_remaining);
                 }

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -152,7 +152,14 @@ fn try_consume_fn<'t, 'r>(
                 if *token == ending_token {
                     trace!(log, "Reached end of raw, returning");
 
-                    let slice = full_text.slice(log, start, end);
+                    let slice = if start == end {
+                        /* Empty raw */
+                        ""
+                    } else {
+                        /* Gather slice from spans */
+                        full_text.slice(log, start, end)
+                    };
+
                     let element = Element::Raw(slice);
                     return Consumption::ok(element, new_remaining);
                 }

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -196,7 +196,7 @@ fn try_consume_fn<'t, 'r>(
         trace!(log, "Appending present token to raw");
 
         // Update last token and slice.
-        end = extracted;
+        end = new_extracted;
         remaining = new_remaining;
     }
 

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -29,6 +29,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     mut remaining: &'r [ExtractedToken<'t>],
+    _full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Consuming tokens until end of raw");
 

--- a/src/parse/rule/impls/text.rs
+++ b/src/parse/rule/impls/text.rs
@@ -29,6 +29,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    _full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Consuming token as plain text element");
 

--- a/src/parse/rule/impls/todo.rs
+++ b/src/parse/rule/impls/todo.rs
@@ -30,6 +30,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     _: &'r [ExtractedToken<'t>],
+    _: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     error!(log, "Encountered unimplemented rule! Returning error");
 

--- a/src/parse/rule/impls/url.rs
+++ b/src/parse/rule/impls/url.rs
@@ -30,6 +30,7 @@ fn try_consume_fn<'t, 'r>(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    _full_text: FullText<'t>,
 ) -> Consumption<'t, 'r> {
     debug!(log, "Consuming token as a URL");
 

--- a/src/parse/rule/mapping.rs
+++ b/src/parse/rule/mapping.rs
@@ -60,7 +60,7 @@ lazy_static! {
             Token::Subscript => vec![RULE_TODO], // TODO
             Token::LeftMonospace => vec![RULE_TODO], // TODO
             Token::RightMonospace => vec![RULE_TODO], // TODO
-            Token::Color => vec![RULE_TODO], // TODO
+            Token::Color => vec![RULE_COLOR],
             Token::Raw => vec![RULE_RAW],
             Token::LeftRaw => vec![RULE_RAW],
             Token::RightRaw => vec![],

--- a/src/parse/rule/mod.rs
+++ b/src/parse/rule/mod.rs
@@ -87,7 +87,7 @@ where
     Success {
         item: T,
         remaining: &'r [ExtractedToken<'t>],
-        error: Option<ParseError>,
+        errors: Vec<ParseError>,
     },
     Failure {
         error: ParseError,
@@ -103,16 +103,16 @@ where
         GenericConsumption::Success {
             item,
             remaining,
-            error: None,
+            errors: Vec::new(),
         }
     }
 
     #[inline]
-    pub fn warn(item: T, remaining: &'r [ExtractedToken<'t>], error: Option<ParseError>) -> Self {
+    pub fn warn(item: T, remaining: &'r [ExtractedToken<'t>], errors: Vec<ParseError>) -> Self {
         GenericConsumption::Success {
             item,
             remaining,
-            error,
+            errors,
         }
     }
 
@@ -130,14 +130,6 @@ where
     }
 
     #[inline]
-    pub fn error(&self) -> Option<&ParseError> {
-        match self {
-            GenericConsumption::Success { error, .. } => error.as_ref(),
-            GenericConsumption::Failure { error } => Some(error),
-        }
-    }
-
-    #[inline]
     pub fn map<F, U>(self, f: F) -> GenericConsumption<'t, 'r, U>
     where
         F: FnOnce(T) -> U,
@@ -147,14 +139,14 @@ where
             GenericConsumption::Success {
                 item,
                 remaining,
-                error,
+                errors,
             } => {
                 let item = f(item);
 
                 GenericConsumption::Success {
                     item,
                     remaining,
-                    error,
+                    errors,
                 }
             }
         }

--- a/src/parse/rule/mod.rs
+++ b/src/parse/rule/mod.rs
@@ -18,7 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use self::collect::collect_until;
 use super::ParseError;
 use crate::parse::token::ExtractedToken;
 use crate::tree::Element;

--- a/src/parse/rule/mod.rs
+++ b/src/parse/rule/mod.rs
@@ -20,6 +20,7 @@
 
 use super::ParseError;
 use crate::parse::token::ExtractedToken;
+use crate::text::FullText;
 use crate::tree::Element;
 use std::fmt::{self, Debug};
 
@@ -50,10 +51,11 @@ impl Rule {
         log: &slog::Logger,
         extract: &'r ExtractedToken<'t>,
         remaining: &'r [ExtractedToken<'t>],
+        full_text: FullText<'t>,
     ) -> Consumption<'r, 't> {
         info!(log, "Trying to consume for parse rule"; "name" => self.name);
 
-        (self.try_consume_fn)(log, extract, remaining)
+        (self.try_consume_fn)(log, extract, remaining, full_text)
     }
 }
 
@@ -164,4 +166,5 @@ pub type TryConsumeFn = for<'t, 'r> fn(
     log: &slog::Logger,
     extracted: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
+    full_text: FullText<'t>,
 ) -> Consumption<'t, 'r>;

--- a/src/parse/rule/mod.rs
+++ b/src/parse/rule/mod.rs
@@ -108,11 +108,11 @@ where
     }
 
     #[inline]
-    pub fn warn(item: T, remaining: &'r [ExtractedToken<'t>], error: ParseError) -> Self {
+    pub fn warn(item: T, remaining: &'r [ExtractedToken<'t>], error: Option<ParseError>) -> Self {
         GenericConsumption::Success {
             item,
             remaining,
-            error: Some(error),
+            error,
         }
     }
 

--- a/src/parse/rule/mod.rs
+++ b/src/parse/rule/mod.rs
@@ -89,17 +89,17 @@ where
     T: 't,
 {
     #[inline]
-    pub fn ok(element: T, remaining: &'r [ExtractedToken<'t>]) -> Self {
+    pub fn ok(item: T, remaining: &'r [ExtractedToken<'t>]) -> Self {
         GenericConsumption {
-            result: GenericConsumptionResult::Success { element, remaining },
+            result: GenericConsumptionResult::Success { item, remaining },
             error: None,
         }
     }
 
     #[inline]
-    pub fn warn(element: T, remaining: &'r [ExtractedToken<'t>], error: ParseError) -> Self {
+    pub fn warn(item: T, remaining: &'r [ExtractedToken<'t>], error: ParseError) -> Self {
         GenericConsumption {
-            result: GenericConsumptionResult::Success { element, remaining },
+            result: GenericConsumptionResult::Success { item, remaining },
             error: Some(error),
         }
     }
@@ -131,9 +131,9 @@ where
     {
         let GenericConsumption { result, error } = self;
         let result = match result {
-            GenericConsumptionResult::Success { element, remaining } => {
+            GenericConsumptionResult::Success { item, remaining } => {
                 GenericConsumptionResult::Success {
-                    element: f(element),
+                    item: f(item),
                     remaining,
                 }
             }
@@ -151,7 +151,7 @@ where
     'r: 't,
 {
     Success {
-        element: T,
+        item: T,
         remaining: &'r [ExtractedToken<'t>],
     },
     Failure,

--- a/src/parse/rule/mod.rs
+++ b/src/parse/rule/mod.rs
@@ -25,7 +25,6 @@ use crate::tree::Element;
 use std::fmt::{self, Debug};
 
 mod collect;
-mod container;
 mod mapping;
 
 pub mod impls;

--- a/src/parse/rule/mod.rs
+++ b/src/parse/rule/mod.rs
@@ -23,6 +23,7 @@ use crate::parse::token::ExtractedToken;
 use crate::tree::Element;
 use std::fmt::{self, Debug};
 
+mod collect;
 mod container;
 mod mapping;
 

--- a/src/parse/rule/mod.rs
+++ b/src/parse/rule/mod.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use self::collect::collect_until;
 use super::ParseError;
 use crate::parse::token::ExtractedToken;
 use crate::tree::Element;
@@ -122,6 +123,24 @@ where
     #[inline]
     pub fn is_error(&self) -> bool {
         !self.is_success()
+    }
+
+    pub fn map<F, U>(self, f: F) -> GenericConsumption<'t, 'r, U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        let GenericConsumption { result, error } = self;
+        let result = match result {
+            GenericConsumptionResult::Success { element, remaining } => {
+                GenericConsumptionResult::Success {
+                    element: f(element),
+                    remaining,
+                }
+            }
+            GenericConsumptionResult::Failure => GenericConsumptionResult::Failure,
+        };
+
+        GenericConsumption { result, error }
     }
 }
 

--- a/src/parse/rule/mod.rs
+++ b/src/parse/rule/mod.rs
@@ -77,38 +77,36 @@ impl slog::Value for Rule {
     }
 }
 
-/// Result of attempting to consume tokens in a parse rule.
 #[derive(Debug, Clone)]
-pub struct Consumption<'t, 'r> {
-    pub result: ConsumptionResult<'t, 'r>,
+pub struct GenericConsumption<'t, 'r, T> {
+    pub result: GenericConsumptionResult<'t, 'r, T>,
     pub error: Option<ParseError>,
 }
 
-impl<'t, 'r> Consumption<'t, 'r> {
+impl<'t, 'r, T> GenericConsumption<'t, 'r, T>
+where
+    T: 't,
+{
     #[inline]
-    pub fn ok(element: Element<'t>, remaining: &'r [ExtractedToken<'t>]) -> Self {
-        Consumption {
-            result: ConsumptionResult::Success { element, remaining },
+    pub fn ok(element: T, remaining: &'r [ExtractedToken<'t>]) -> Self {
+        GenericConsumption {
+            result: GenericConsumptionResult::Success { element, remaining },
             error: None,
         }
     }
 
     #[inline]
-    pub fn warn(
-        element: Element<'t>,
-        remaining: &'r [ExtractedToken<'t>],
-        error: ParseError,
-    ) -> Self {
-        Consumption {
-            result: ConsumptionResult::Success { element, remaining },
+    pub fn warn(element: T, remaining: &'r [ExtractedToken<'t>], error: ParseError) -> Self {
+        GenericConsumption {
+            result: GenericConsumptionResult::Success { element, remaining },
             error: Some(error),
         }
     }
 
     #[inline]
     pub fn err(error: ParseError) -> Self {
-        Consumption {
-            result: ConsumptionResult::Failure,
+        GenericConsumption {
+            result: GenericConsumptionResult::Failure,
             error: Some(error),
         }
     }
@@ -116,8 +114,8 @@ impl<'t, 'r> Consumption<'t, 'r> {
     #[inline]
     pub fn is_success(&self) -> bool {
         match self.result {
-            ConsumptionResult::Success { .. } => true,
-            ConsumptionResult::Failure => false,
+            GenericConsumptionResult::Success { .. } => true,
+            GenericConsumptionResult::Failure => false,
         }
     }
 
@@ -128,16 +126,20 @@ impl<'t, 'r> Consumption<'t, 'r> {
 }
 
 #[derive(Debug, Clone)]
-pub enum ConsumptionResult<'t, 'r>
+pub enum GenericConsumptionResult<'t, 'r, T>
 where
+    T: 't,
     'r: 't,
 {
     Success {
-        element: Element<'t>,
+        element: T,
         remaining: &'r [ExtractedToken<'t>],
     },
     Failure,
 }
+
+pub type Consumption<'t, 'r> = GenericConsumption<'t, 'r, Element<'t>>;
+pub type ConsumptionResult<'t, 'r> = GenericConsumptionResult<'t, 'r, Element<'t>>;
 
 /// The function type for actually trying to consume tokens
 pub type TryConsumeFn = for<'t, 'r> fn(

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -64,8 +64,23 @@ fn ast() {
     }
 
     macro_rules! container {
+        // For plain enum container types
         ($type:tt, $elements:expr) => {
-            Element::Container(Container::new(ContainerType::$type, $elements))
+            container!(ContainerType::$type; $elements)
+        };
+
+        // For container types with added data
+        ($type:expr; $elements:expr) => {
+            Element::Container(Container::new($type, $elements))
+        };
+
+        // Comma variants
+        ($type:tt, $elements:expr,) => {
+            container!($type, $elements)
+        };
+
+        ($type:expr; $elements:expr,) => {
+            container!($type; $elements)
         };
     }
 
@@ -296,6 +311,19 @@ fn ast() {
                 ParseErrorKind::NoRulesMatch,
             ),
         ],
+    );
+
+    test!(
+        "##blue|text here",
+        vec![container!(
+            ContainerType::Color("blue");
+            vec![
+                Element::Text("text"),
+                Element::Text(" "),
+                Element::Text("here"),
+            ],
+        )],
+        vec![],
     );
 }
 

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -348,14 +348,12 @@ fn ast() {
             Element::Text(" "),
             Element::Text("color"),
         ],
-        vec![
-            ParseError::new_raw(
-                Token::Color,
-                "fallback",
-                0..2,
-                ParseErrorKind::NoRulesMatch,
-            ),
-        ],
+        vec![ParseError::new_raw(
+            Token::Color,
+            "fallback",
+            0..2,
+            ParseErrorKind::NoRulesMatch,
+        )],
     );
 
     test!(
@@ -370,7 +368,7 @@ fn ast() {
         ],
         vec![
             ParseError::new_raw(
-                Token::Color,
+                Token::Color, //
                 "fallback",
                 0..2,
                 ParseErrorKind::NoRulesMatch,

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -188,18 +188,18 @@ fn ast() {
         )],
     );
 
-    test!("@@@@", vec![Element::Raw(vec![])], vec![]);
+    test!("@@@@", vec![Element::Raw("")], vec![]);
 
-    test!("@@@@@", vec![Element::Raw(vec!["@"])], vec![]);
+    test!("@@@@@", vec![Element::Raw("@")], vec![]);
 
-    test!("@@@@@@", vec![Element::Raw(vec!["@@"])], vec![]);
+    test!("@@@@@@", vec![Element::Raw("@@")], vec![]);
 
     test!(
         "test @@@@ string",
         vec![
             Element::Text("test"),
             Element::Text(" "),
-            Element::Raw(vec![]),
+            Element::Raw(""),
             Element::Text(" "),
             Element::Text("string"),
         ],
@@ -211,20 +211,18 @@ fn ast() {
         vec![
             Element::Text("test"),
             Element::Text(" "),
-            Element::Raw(vec!["@@"]),
+            Element::Raw("@@"),
             Element::Text(" "),
             Element::Text("string"),
         ],
         vec![],
     );
 
-    test!("@<>@", vec![Element::Raw(vec![])], vec![],);
+    test!("@<>@", vec![Element::Raw("")], vec![],);
 
     test!(
         "@@raw @< >@ content@@",
-        vec![Element::Raw(vec![
-            "raw", " ", "@<", " ", ">@", " ", "content",
-        ])],
+        vec![Element::Raw("raw @< >@ content")],
         vec![],
     );
 
@@ -233,7 +231,7 @@ fn ast() {
         vec![
             Element::Text("not"),
             Element::Text(" "),
-            Element::Raw(vec!["**"],),
+            Element::Raw("**",),
             Element::Text(" "),
             Element::Text("bold"),
         ],
@@ -242,7 +240,7 @@ fn ast() {
 
     test!(
         "@<raw @@ content>@",
-        vec![Element::Raw(vec!["raw", " ", "@@", " ", "content"])],
+        vec![Element::Raw("raw @@ content")],
         vec![],
     );
 

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -325,6 +325,64 @@ fn ast() {
         )],
         vec![],
     );
+
+    test!(
+        "###ccc|css color!##",
+        vec![container!(
+            ContainerType::Color("#ccc");
+            vec![
+                Element::Text("css"),
+                Element::Text(" "),
+                Element::Text("color"),
+                Element::Text("!"),
+            ],
+        )],
+        vec![],
+    );
+
+    test!(
+        "##not color",
+        vec![
+            Element::Text("##"),
+            Element::Text("not"),
+            Element::Text(" "),
+            Element::Text("color"),
+        ],
+        vec![
+            ParseError::new_raw(
+                Token::Color,
+                "fallback",
+                0..2,
+                ParseErrorKind::NoRulesMatch,
+            ),
+        ],
+    );
+
+    test!(
+        "##invalid\n|text##",
+        vec![
+            Element::Text("##"),
+            Element::Text("invalid"),
+            Element::LineBreak,
+            Element::Text("|"),
+            Element::Text("text"),
+            Element::Text("##"),
+        ],
+        vec![
+            ParseError::new_raw(
+                Token::Color,
+                "fallback",
+                0..2,
+                ParseErrorKind::NoRulesMatch,
+            ),
+            ParseError::new_raw(
+                Token::Color,
+                "fallback",
+                15..17,
+                ParseErrorKind::NoRulesMatch,
+            ),
+        ],
+    );
 }
 
 #[test]

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -314,7 +314,7 @@ fn ast() {
     );
 
     test!(
-        "##blue|text here",
+        "##blue|text here##",
         vec![container!(
             ContainerType::Color("blue");
             vec![

--- a/src/text.rs
+++ b/src/text.rs
@@ -42,14 +42,26 @@ impl<'t> FullText<'t> {
     /// If the ending token does not come after the first, or if
     /// the slices specified are out of range for the string (unlikely),
     /// this function will panic.
-    pub fn slice(&self, start_token: &ExtractedToken, end_token: &ExtractedToken) -> &'t str {
+    pub fn slice(
+        &self,
+        log: &slog::Logger,
+        start_token: &ExtractedToken,
+        end_token: &ExtractedToken,
+    ) -> &'t str {
         let start = start_token.span.start;
         let end = end_token.span.end;
+
+        debug!(
+            log,
+            "Extracting slice from full text";
+            "start" => start,
+            "end" => end,
+        );
 
         if start > end {
             panic!(
                 "Starting index is later than the ending index: {} > {}",
-                start, end
+                start, end,
             );
         }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,55 @@
+/*
+ * text.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use crate::ExtractedToken;
+
+/// Wrapper for the input string that was tokenized.
+///
+/// This structure does not expose the internal string (preventing weird ad-hoc
+/// or hack parsing), but permits joining adjacent `ExtractedToken` string slices
+/// by selecting from the original text source.
+#[derive(Debug, Copy, Clone)]
+pub struct FullText<'t> {
+    text: &'t str,
+}
+
+impl<'t> FullText<'t> {
+    #[inline]
+    pub fn new(text: &'t str) -> Self {
+        FullText { text }
+    }
+
+    /// Slices from the given start to end token.
+    ///
+    /// # Panics
+    /// If the ending token does not come after the first, or if
+    /// the slices specified are out of range for the string (unlikely),
+    /// this function will panic.
+    pub fn slice(&self, start_token: &ExtractedToken, end_token: &ExtractedToken) -> &'t str {
+        let start = start_token.span.start;
+        let end = end_token.span.end;
+
+        if start > end {
+            panic!("Starting index is later than the ending index: {} > {}", start, end);
+        }
+
+        &self.text[start..end]
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -47,7 +47,10 @@ impl<'t> FullText<'t> {
         let end = end_token.span.end;
 
         if start > end {
-            panic!("Starting index is later than the ending index: {} > {}", start, end);
+            panic!(
+                "Starting index is later than the ending index: {} > {}",
+                start, end
+            );
         }
 
         &self.text[start..end]

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -27,6 +27,18 @@ pub struct Tokenization<'t> {
     full_text: FullText<'t>,
 }
 
+impl<'t> Tokenization<'t> {
+    #[inline]
+    pub(crate) fn tokens<'r>(&'r self) -> &'r [ExtractedToken<'t>] {
+        &self.tokens
+    }
+
+    #[inline]
+    pub(crate) fn full_text(&self) -> FullText<'t> {
+        self.full_text
+    }
+}
+
 impl<'t> Into<Vec<ExtractedToken<'t>>> for Tokenization<'t> {
     #[inline]
     fn into(self) -> Vec<ExtractedToken<'t>> {

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -1,0 +1,52 @@
+/*
+ * tokenize.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use crate::text::FullText;
+use crate::{ExtractedToken, Token};
+
+#[derive(Debug, Clone)]
+pub struct Tokenization<'t> {
+    tokens: Vec<ExtractedToken<'t>>,
+    full_text: FullText<'t>,
+}
+
+impl<'t> Into<Vec<ExtractedToken<'t>>> for Tokenization<'t> {
+    #[inline]
+    fn into(self) -> Vec<ExtractedToken<'t>> {
+        self.tokens
+    }
+}
+
+/// Take an input string and produce a list of tokens for consumption by the parser.
+pub fn tokenize<'t>(log: &slog::Logger, text: &'t str) -> Tokenization<'t> {
+    let log = &log.new(slog_o!(
+        "filename" => slog_filename!(),
+        "lineno" => slog_lineno!(),
+        "function" => "tokenize",
+        "text" => str!(text),
+    ));
+
+    info!(log, "Running lexer on text");
+
+    let tokens = Token::extract_all(log, text);
+    let full_text = FullText::new(text);
+
+    Tokenization { tokens, full_text }
+}

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -26,16 +26,16 @@ use strum_macros::IntoStaticStr;
 
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub struct Container<'a> {
+pub struct Container<'t> {
     #[serde(rename = "type")]
-    etype: ContainerType,
+    etype: ContainerType<'t>,
 
-    elements: Vec<Element<'a>>,
+    elements: Vec<Element<'t>>,
 }
 
-impl<'a> Container<'a> {
+impl<'t> Container<'t> {
     #[inline]
-    pub fn new(etype: ContainerType, elements: Vec<Element<'a>>) -> Self {
+    pub fn new(etype: ContainerType<'t>, elements: Vec<Element<'t>>) -> Self {
         Container { etype, elements }
     }
 
@@ -45,14 +45,14 @@ impl<'a> Container<'a> {
     }
 
     #[inline]
-    pub fn elements(&self) -> &[Element<'a>] {
+    pub fn elements(&self) -> &[Element<'t>] {
         &self.elements
     }
 }
 
-impl<'a> Into<Vec<Element<'a>>> for Container<'a> {
+impl<'t> Into<Vec<Element<'t>>> for Container<'t> {
     #[inline]
-    fn into(self) -> Vec<Element<'a>> {
+    fn into(self) -> Vec<Element<'t>> {
         let Container { elements, .. } = self;
 
         elements
@@ -61,7 +61,7 @@ impl<'a> Into<Vec<Element<'a>>> for Container<'a> {
 
 #[derive(Serialize, Deserialize, IntoStaticStr, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub enum ContainerType {
+pub enum ContainerType<'t> {
     Paragraph,
     Bold,
     Italics,
@@ -70,17 +70,18 @@ pub enum ContainerType {
     Subscript,
     Strikethrough,
     Monospace,
+    Color(&'t str),
     Header(HeadingLevel),
 }
 
-impl ContainerType {
+impl ContainerType<'_> {
     #[inline]
     pub fn name(self) -> &'static str {
         self.into()
     }
 }
 
-impl slog::Value for ContainerType {
+impl slog::Value for ContainerType<'_> {
     fn serialize(
         &self,
         _: &slog::Record,

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -39,7 +39,7 @@ pub enum Element<'t> {
     /// This should be formatted exactly as listed.
     /// For instance, spaces being rendered to HTML should
     /// produce a `&nbsp;`.
-    Raw(Vec<&'t str>),
+    Raw(&'t str),
 
     /// An element indicating an email.
     ///

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -23,29 +23,29 @@ use crate::enums::{AnchorTarget, LinkLabel};
 
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", tag = "element", content = "data")]
-pub enum Element<'a> {
+pub enum Element<'t> {
     /// An element which contains other elements within it.
     ///
     /// Examples would include italics, paragraphs, divs, etc.
-    Container(Container<'a>),
+    Container(Container<'t>),
 
     /// An element only containing text.
     ///
     /// Should be formatted like typical body text.
-    Text(&'a str),
+    Text(&'t str),
 
     /// Raw text.
     ///
     /// This should be formatted exactly as listed.
     /// For instance, spaces being rendered to HTML should
     /// produce a `&nbsp;`.
-    Raw(Vec<&'a str>),
+    Raw(Vec<&'t str>),
 
     /// An element indicating an email.
     ///
     /// Whether this should become a clickable href link or just text
     /// is up to the render implementation.
-    Email(&'a str),
+    Email(&'t str),
 
     /// An element linking to a different page.
     ///
@@ -54,8 +54,8 @@ pub enum Element<'a> {
     ///
     /// The "url" field is either a page name (relative URL) or full URL.
     Link {
-        url: &'a str,
-        label: LinkLabel<'a>,
+        url: &'t str,
+        label: LinkLabel<'t>,
         anchor: AnchorTarget,
     },
 


### PR DESCRIPTION
This adds support for the `##color|text here blah...##` pattern in Wikidot for creating colored text.

It also changes `Consumption` to be directly an enum, thus exposing a mandatory `error` field for failures, and adds `FullText<'t>` to allow slicing from a pair of `ExtractedToken<'t>`s.