### PR TITLE
Initial version of render code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ pest = "2"
 pest_derive = "2"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 slog = "2.5"
 str-macro = "0.1"
 strum = "0.20"
@@ -30,6 +31,5 @@ strum_macros = "0.20"
 tinyvec = "1"
 
 [dev-dependencies]
-serde_json = "1"
 sloggers = "1"
 slog-bunyan = "2"

--- a/src/data/page_info.rs
+++ b/src/data/page_info.rs
@@ -24,6 +24,11 @@ use std::borrow::Cow;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct PageInfo<'a> {
+    /// The slug for this page.
+    ///
+    /// That is, the page component of the URL.
+    pub slug: Cow<'a, str>,
+
     /// The title of this page.
     ///
     /// For SCPs this is "SCP-XXXX".

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,9 @@ mod test;
 #[macro_use]
 mod log;
 
+#[macro_use]
+mod macros;
+
 mod enums;
 mod parse;
 mod preproc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub use self::parse::{
     parse, ExtractedToken, ParseError, ParseErrorKind, ParseResult, Token,
 };
 pub use self::preproc::preprocess;
-pub use self::render::Render;
+pub use self::render::*;
 pub use self::tokenize::{tokenize, Tokenization};
 
 pub mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ mod log;
 mod enums;
 mod parse;
 mod preproc;
+mod render;
 mod text;
 mod tokenize;
 
@@ -81,6 +82,7 @@ pub use self::parse::{
     parse, ExtractedToken, ParseError, ParseErrorKind, ParseResult, Token,
 };
 pub use self::preproc::preprocess;
+pub use self::render::Render;
 pub use self::tokenize::{tokenize, Tokenization};
 
 pub mod prelude {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,5 @@
 /*
- * render/mod.rs
+ * macros.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,15 +18,20 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use super::Render;
-    pub use crate::tree::{Container, ContainerType, Element, SyntaxTree};
+/// Alias for `Cow::Borrowed` that isn't quite as long.
+macro_rules! cow {
+    ($value:expr) => {{
+        use std::borrow::Cow;
+
+        Cow::Borrowed($value)
+    }};
 }
 
-mod json;
-mod null;
-mod object;
+/// Alias for `Element::Text` from a string slice.
+macro_rules! text {
+    ($value:expr) => {{
+        use crate::tree::Element;
 
-pub use self::json::JsonRender;
-pub use self::null::NullRender;
-pub use self::object::Render;
+        Element::Text(cow!($value))
+    }};
+}

--- a/src/parse/macros.rs
+++ b/src/parse/macros.rs
@@ -54,21 +54,3 @@ macro_rules! try_consume_last {
         (item, extracted, new_remaining, errors)
     }};
 }
-
-/// Alias for `Cow::Borrowed` that isn't quite as long.
-macro_rules! cow {
-    ($value:expr) => {{
-        use std::borrow::Cow;
-
-        Cow::Borrowed($value)
-    }};
-}
-
-/// Alias for `Element::Text` from a string slice.
-macro_rules! text {
-    ($value:expr) => {{
-        use crate::tree::Element;
-
-        Element::Text(cow!($value))
-    }};
-}

--- a/src/render/debug.rs
+++ b/src/render/debug.rs
@@ -1,0 +1,80 @@
+/*
+ * render/debug.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! A simple renderer that outputs the `SyntaxTree` using Rust's debug formatter.
+
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct DebugRender;
+
+impl Render for DebugRender {
+    #[inline]
+    fn render(&self, tree: &SyntaxTree) -> String {
+        format!("{:#?}", tree)
+    }
+}
+
+#[test]
+fn debug() {
+    // Expected outputs
+    const OUTPUT: &str = r#"SyntaxTree {
+    elements: [
+        Text(
+            "apple",
+        ),
+        Text(
+            " ",
+        ),
+        Container(
+            Container {
+                ctype: Bold,
+                elements: [
+                    Text(
+                        "banana",
+                    ),
+                ],
+            },
+        ),
+    ],
+    styles: [
+        "span.hidden-text { display: none; }",
+    ],
+}"#;
+
+    // Syntax tree construction
+    let elements = vec![
+        text!("apple"),
+        text!(" "),
+        Element::Container(Container::new(ContainerType::Bold, vec![text!("banana")])),
+    ];
+    let errors = vec![];
+    let styles = vec![cow!("span.hidden-text { display: none; }")];
+
+    let result = SyntaxTree::from_element_result(elements, errors, styles);
+    let (tree, _) = result.into();
+
+    // Perform rendering
+    let output = DebugRender.render(&tree);
+    assert_eq!(
+        output, OUTPUT,
+        "Pretty JSON syntax tree output doesn't match",
+    );
+}

--- a/src/render/debug.rs
+++ b/src/render/debug.rs
@@ -26,6 +26,8 @@ use super::prelude::*;
 pub struct DebugRender;
 
 impl Render for DebugRender {
+    type Output = String;
+
     #[inline]
     fn render(&self, tree: &SyntaxTree) -> String {
         format!("{:#?}", tree)

--- a/src/render/html/builder.rs
+++ b/src/render/html/builder.rs
@@ -1,0 +1,202 @@
+/*
+ * render/html/builder.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::context::HtmlContext;
+use super::escape::escape_char;
+use super::render::ElementRender;
+
+macro_rules! tag_method {
+    ($tag:tt) => {
+        pub fn $tag(self) -> HtmlBuilderTag<'c, 'i, 'h, 'static> {
+            self.tag(stringify!($tag))
+        }
+    };
+}
+
+// Main struct
+
+#[derive(Debug)]
+pub struct HtmlBuilder<'c, 'i, 'h> {
+    ctx: &'c mut HtmlContext<'i, 'h>,
+}
+
+impl<'c, 'i, 'h> HtmlBuilder<'c, 'i, 'h> {
+    #[inline]
+    pub fn new(ctx: &'c mut HtmlContext<'i, 'h>) -> Self {
+        HtmlBuilder { ctx }
+    }
+
+    #[inline]
+    pub fn tag<'t>(self, tag: &'t str) -> HtmlBuilderTag<'c, 'i, 'h, 't> {
+        debug_assert!(is_alphanumeric(tag));
+
+        let HtmlBuilder { ctx } = self;
+        HtmlBuilderTag::new(ctx, tag)
+    }
+
+    tag_method!(a);
+    tag_method!(b);
+    tag_method!(blockquote);
+    tag_method!(br);
+    tag_method!(code);
+    tag_method!(div);
+    tag_method!(hr);
+    tag_method!(i);
+    tag_method!(iframe);
+    tag_method!(img);
+    tag_method!(li);
+    tag_method!(ol);
+    tag_method!(p);
+    tag_method!(script);
+    tag_method!(span);
+    tag_method!(strike);
+    tag_method!(sub);
+    tag_method!(sup);
+    tag_method!(table);
+    tag_method!(tr);
+    tag_method!(tt);
+    tag_method!(u);
+    tag_method!(ul);
+
+    #[inline]
+    pub fn text(&mut self, text: &str) {
+        self.ctx.push_escaped(text);
+    }
+}
+
+// Helper structs
+
+#[derive(Debug)]
+pub struct HtmlBuilderTag<'c, 'i, 'h, 't> {
+    ctx: &'c mut HtmlContext<'i, 'h>,
+    tag: &'t str,
+    in_tag: bool,
+}
+
+impl<'c, 'i, 'h, 't> HtmlBuilderTag<'c, 'i, 'h, 't> {
+    pub fn new(ctx: &'c mut HtmlContext<'i, 'h>, tag: &'t str) -> Self {
+        ctx.push_raw('<');
+        ctx.push_raw_str(tag);
+
+        HtmlBuilderTag {
+            ctx,
+            tag,
+            in_tag: true,
+        }
+    }
+
+    fn attr_key(&mut self, key: &str) {
+        debug_assert!(is_alphanumeric(key));
+        debug_assert!(self.in_tag);
+
+        self.ctx.push_raw(' ');
+        self.ctx.push_escaped(key);
+        self.ctx.push_raw('=');
+    }
+
+    pub fn attr(&mut self, key: &str, value_parts: &[&str]) -> &mut Self {
+        self.attr_key(key);
+        self.ctx.push_raw('"');
+        for part in value_parts {
+            self.ctx.push_escaped(part);
+        }
+        self.ctx.push_raw('"');
+
+        self
+    }
+
+    pub fn attr_fmt<F>(&mut self, key: &str, mut value_fn: F) -> &mut Self
+    where
+        F: FnMut(&mut HtmlContext),
+    {
+        self.attr_key(key);
+        self.ctx.push_raw('"');
+
+        // Read the formatted text and escape it.
+        // Assumes all escaped characters are ASCII (see html::escape).
+        // Also assumes all changes to buffer were appended only.
+        let mut index = self.ctx.buffer().len();
+        value_fn(self.ctx);
+
+        let buffer = self.ctx.buffer();
+        while index < buffer.len() {
+            let ch = {
+                let remainder = &buffer[index..];
+                remainder
+                    .chars()
+                    .next()
+                    .expect("Character buffer exhausted")
+            };
+
+            if let Some(subst) = escape_char(ch) {
+                buffer.replace_range(index..=index, subst);
+            }
+
+            index += ch.len_utf8();
+        }
+        self.ctx.push_raw('"');
+
+        self
+    }
+
+    fn content_start(&mut self) {
+        if self.in_tag {
+            self.ctx.push_raw('>');
+            self.in_tag = false;
+        }
+    }
+
+    #[inline]
+    pub fn inner(&mut self, component: &dyn ElementRender) -> &mut Self {
+        self.content_start();
+        component.render(self.ctx);
+
+        self
+    }
+
+    pub fn contents<F>(&mut self, mut f: F) -> &mut Self
+    where
+        F: FnMut(&mut HtmlContext),
+    {
+        self.content_start();
+        f(self.ctx);
+
+        self
+    }
+}
+
+impl<'c, 'i, 'h, 't> Drop for HtmlBuilderTag<'c, 'i, 'h, 't> {
+    fn drop(&mut self) {
+        if !self.in_tag {
+            self.ctx.push_raw_str("</");
+            self.ctx.push_raw_str(self.tag);
+        }
+
+        self.ctx.push_raw('>');
+    }
+}
+
+// Helpers
+
+fn is_alphanumeric(value: &str) -> bool {
+    value
+        .chars()
+        .all(|c| c.is_ascii_alphabetic() || c.is_ascii_digit() || c == '-')
+}

--- a/src/render/html/context.rs
+++ b/src/render/html/context.rs
@@ -128,13 +128,12 @@ impl<'i, 'h> HtmlContext<'i, 'h> {
     }
 }
 
-impl<'i, 'h> Into<HtmlOutput<'i>> for HtmlContext<'i, 'h> {
-    fn into(self) -> HtmlOutput<'i> {
+impl<'i, 'h> Into<HtmlOutput> for HtmlContext<'i, 'h> {
+    fn into(self) -> HtmlOutput {
         let HtmlContext {
             html,
             style,
             meta,
-            info,
             ..
         } = self;
 
@@ -142,7 +141,6 @@ impl<'i, 'h> Into<HtmlOutput<'i>> for HtmlContext<'i, 'h> {
             html,
             style,
             meta,
-            info,
         }
     }
 }

--- a/src/render/html/context.rs
+++ b/src/render/html/context.rs
@@ -1,0 +1,155 @@
+/*
+ * render/html/context.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::builder::HtmlBuilder;
+use super::escape::escape;
+use super::meta::{HtmlMeta, HtmlMetaType};
+use super::output::HtmlOutput;
+use crate::data::PageInfo;
+use std::fmt::{self, Write};
+
+#[derive(Debug)]
+pub struct HtmlContext<'i, 'h> {
+    html: String,
+    style: String,
+    meta: Vec<HtmlMeta>,
+    info: PageInfo<'i>,
+    handle: &'h (),
+}
+
+impl<'i, 'h> HtmlContext<'i, 'h> {
+    #[inline]
+    pub fn new(info: PageInfo<'i>, handle: &'h ()) -> Self {
+        HtmlContext {
+            html: String::new(),
+            style: String::new(),
+            meta: Self::initial_metadata(&info),
+            info,
+            handle,
+        }
+    }
+
+    fn initial_metadata(info: &PageInfo<'i>) -> Vec<HtmlMeta> {
+        // Initial version, we can tune how the metadata is generated later.
+
+        vec![
+            HtmlMeta {
+                tag_type: HtmlMetaType::HttpEquiv,
+                name: str!("Content-Type"),
+                value: str!("text/html"),
+            },
+            HtmlMeta {
+                tag_type: HtmlMetaType::Name,
+                name: str!("generator"),
+                value: format!("ftml {}", env!("CARGO_PKG_VERSION")),
+            },
+            HtmlMeta {
+                tag_type: HtmlMetaType::Name,
+                name: str!("description"),
+                value: {
+                    let mut value = str!(info.title);
+
+                    if let Some(ref alt_title) = info.alt_title {
+                        write!(&mut value, " - {}", alt_title).unwrap();
+                    }
+
+                    value
+                },
+            },
+            HtmlMeta {
+                tag_type: HtmlMetaType::Name,
+                name: str!("keywords"),
+                value: info.tags.join(","),
+            },
+        ]
+    }
+
+    // Field access
+    #[inline]
+    pub fn info(&self) -> &PageInfo<'i> {
+        &self.info
+    }
+
+    #[inline]
+    pub fn handle(&self) -> &'h () {
+        self.handle
+    }
+
+    // Buffer management
+    #[inline]
+    pub fn buffer(&mut self) -> &mut String {
+        &mut self.html
+    }
+
+    #[inline]
+    pub fn add_style(&mut self, style: &str) {
+        if !self.style.is_empty() {
+            self.style.push('\n');
+        }
+
+        self.style.push_str(style);
+    }
+
+    #[inline]
+    pub fn push_raw(&mut self, ch: char) {
+        self.buffer().push(ch);
+    }
+
+    #[inline]
+    pub fn push_raw_str(&mut self, s: &str) {
+        self.buffer().push_str(s);
+    }
+
+    #[inline]
+    pub fn push_escaped(&mut self, s: &str) {
+        escape(self.buffer(), s);
+    }
+
+    #[inline]
+    pub fn html(&mut self) -> HtmlBuilder<'_, 'i, 'h> {
+        HtmlBuilder::new(self)
+    }
+}
+
+impl<'i, 'h> Into<HtmlOutput<'i>> for HtmlContext<'i, 'h> {
+    fn into(self) -> HtmlOutput<'i> {
+        let HtmlContext {
+            html,
+            style,
+            meta,
+            info,
+            ..
+        } = self;
+
+        HtmlOutput {
+            html,
+            style,
+            meta,
+            info,
+        }
+    }
+}
+
+impl<'i, 'h> Write for HtmlContext<'i, 'h> {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.buffer().write_str(s)
+    }
+}

--- a/src/render/html/context.rs
+++ b/src/render/html/context.rs
@@ -131,17 +131,10 @@ impl<'i, 'h> HtmlContext<'i, 'h> {
 impl<'i, 'h> Into<HtmlOutput> for HtmlContext<'i, 'h> {
     fn into(self) -> HtmlOutput {
         let HtmlContext {
-            html,
-            style,
-            meta,
-            ..
+            html, style, meta, ..
         } = self;
 
-        HtmlOutput {
-            html,
-            style,
-            meta,
-        }
+        HtmlOutput { html, style, meta }
     }
 }
 

--- a/src/render/html/escape.rs
+++ b/src/render/html/escape.rs
@@ -1,0 +1,63 @@
+/*
+ * render/html/escape.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pub fn escape_char(c: char) -> Option<&'static str> {
+    match c {
+        '>' => Some("&gt;"),
+        '<' => Some("&lt;"),
+        '&' => Some("&amp;"),
+        '\'' => Some("&#39;"),
+        '\"' => Some("&quot;"),
+        _ => None,
+    }
+}
+
+pub fn escape(buffer: &mut String, s: &str) {
+    for ch in s.chars() {
+        match escape_char(ch) {
+            Some(s) => buffer.push_str(s),
+            None => buffer.push(ch),
+        }
+    }
+}
+
+#[test]
+fn test() {
+    macro_rules! check {
+        ($input:expr, $expected:expr) => {{
+            let mut buffer = String::new();
+            escape(&mut buffer, $input);
+
+            assert_eq!(&buffer, $expected, "Escaped HTML doesn't match expected",);
+        }};
+    }
+
+    check!("", "");
+    check!("Hello, world!", "Hello, world!");
+    check!("x + 3 > 19, solve for x", "x + 3 &gt; 19, solve for x");
+    check!(
+        "<script>alert('test');</script>",
+        "&lt;script&gt;alert(&#39;test&#39;);&lt;/script&gt;"
+    );
+    check!(
+        "S & C Plastic's location",
+        "S &amp; C Plastic&#39;s location"
+    );
+}

--- a/src/render/html/macros.rs
+++ b/src/render/html/macros.rs
@@ -1,5 +1,5 @@
 /*
- * render/html/mod.rs
+ * render/html/macros.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,22 +18,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#[cfg(test)]
-mod test;
+/// Like `std::write()`, except it asserts the writing succeeded.
+///
+/// This is done because the only failure mode for writing to a `String`
+/// would be insufficient memory, which would cause an abort anyways.
+macro_rules! str_write {
+    ($dest:expr, $($arg:tt)*) => {{
+        use std::fmt::Write;
 
-#[macro_use]
-mod macros;
-
-mod builder;
-mod context;
-mod escape;
-mod meta;
-mod object;
-mod output;
-mod render;
-
-use super::prelude;
-
-pub use self::meta::{HtmlMeta, HtmlMetaType};
-pub use self::object::HtmlRender;
-pub use self::output::HtmlOutput;
+        write!($dest, $($arg)*).expect("Writing to string failed");
+    }};
+}

--- a/src/render/html/meta.rs
+++ b/src/render/html/meta.rs
@@ -1,0 +1,58 @@
+/*
+ * render/html/meta.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::escape as html;
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum HtmlMetaType {
+    Name,
+    HttpEquiv,
+    Property,
+}
+
+impl HtmlMetaType {
+    pub fn tag_name(self) -> &'static str {
+        use self::HtmlMetaType::*;
+
+        match self {
+            Name => "name",
+            HttpEquiv => "http-equiv",
+            Property => "property",
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct HtmlMeta {
+    pub tag_type: HtmlMetaType,
+    pub name: String,
+    pub value: String,
+}
+
+impl HtmlMeta {
+    pub fn render(&self, buffer: &mut String) {
+        str_write!(buffer, "<meta {}=\"", self.tag_type.tag_name());
+        html::escape(buffer, &self.name);
+        buffer.push_str("\" content=\"");
+        html::escape(buffer, &self.value);
+        buffer.push_str("\" />");
+    }
+}

--- a/src/render/html/mod.rs
+++ b/src/render/html/mod.rs
@@ -18,6 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// TODO! remove when this is implemented
+#![allow(dead_code)]
+
 #[cfg(test)]
 mod test;
 

--- a/src/render/html/mod.rs
+++ b/src/render/html/mod.rs
@@ -1,5 +1,5 @@
 /*
- * render/mod.rs
+ * render/html/mod.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,19 +18,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use super::Render;
-    pub use crate::tree::{Container, ContainerType, Element, SyntaxTree};
-}
+#[cfg(test)]
+mod test;
 
-mod debug;
-mod html;
-mod json;
-mod null;
 mod object;
 
-pub use self::debug::DebugRender;
-pub use self::html::HtmlRender;
-pub use self::json::JsonRender;
-pub use self::null::NullRender;
-pub use self::object::Render;
+use super::prelude;
+
+pub use self::object::HtmlRender;

--- a/src/render/html/object.rs
+++ b/src/render/html/object.rs
@@ -25,6 +25,8 @@ pub struct HtmlRender;
 
 impl Render for HtmlRender {
     fn render(&self, tree: &SyntaxTree) -> String {
-        todo!()
+        // TODO
+
+        str!("not implemented")
     }
 }

--- a/src/render/html/object.rs
+++ b/src/render/html/object.rs
@@ -1,5 +1,5 @@
 /*
- * render/mod.rs
+ * render/html/object.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,19 +18,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use super::Render;
-    pub use crate::tree::{Container, ContainerType, Element, SyntaxTree};
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct HtmlRender;
+
+impl Render for HtmlRender {
+    fn render(&self, tree: &SyntaxTree) -> String {
+        todo!()
+    }
 }
-
-mod debug;
-mod html;
-mod json;
-mod null;
-mod object;
-
-pub use self::debug::DebugRender;
-pub use self::html::HtmlRender;
-pub use self::json::JsonRender;
-pub use self::null::NullRender;
-pub use self::object::Render;

--- a/src/render/html/object.rs
+++ b/src/render/html/object.rs
@@ -18,15 +18,16 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::output::HtmlOutput;
 use super::prelude::*;
 
 #[derive(Debug)]
 pub struct HtmlRender;
 
 impl Render for HtmlRender {
-    fn render(&self, _tree: &SyntaxTree) -> String {
-        // TODO
+    type Output = HtmlOutput;
 
-        str!("not implemented")
+    fn render(&self, _tree: &SyntaxTree) -> HtmlOutput {
+        todo!()
     }
 }

--- a/src/render/html/object.rs
+++ b/src/render/html/object.rs
@@ -24,7 +24,7 @@ use super::prelude::*;
 pub struct HtmlRender;
 
 impl Render for HtmlRender {
-    fn render(&self, tree: &SyntaxTree) -> String {
+    fn render(&self, _tree: &SyntaxTree) -> String {
         // TODO
 
         str!("not implemented")

--- a/src/render/html/output.rs
+++ b/src/render/html/output.rs
@@ -1,5 +1,5 @@
 /*
- * render/html/mod.rs
+ * render/html/output.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,22 +18,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#[cfg(test)]
-mod test;
+use super::meta::HtmlMeta;
+use crate::data::PageInfo;
 
-#[macro_use]
-mod macros;
-
-mod builder;
-mod context;
-mod escape;
-mod meta;
-mod object;
-mod output;
-mod render;
-
-use super::prelude;
-
-pub use self::meta::{HtmlMeta, HtmlMetaType};
-pub use self::object::HtmlRender;
-pub use self::output::HtmlOutput;
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct HtmlOutput<'i> {
+    pub html: String,
+    pub style: String,
+    pub meta: Vec<HtmlMeta>,
+    pub info: PageInfo<'i>,
+}

--- a/src/render/html/output.rs
+++ b/src/render/html/output.rs
@@ -19,12 +19,10 @@
  */
 
 use super::meta::HtmlMeta;
-use crate::data::PageInfo;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct HtmlOutput<'i> {
+pub struct HtmlOutput {
     pub html: String,
     pub style: String,
     pub meta: Vec<HtmlMeta>,
-    pub info: PageInfo<'i>,
 }

--- a/src/render/html/render.rs
+++ b/src/render/html/render.rs
@@ -1,5 +1,5 @@
 /*
- * render/html/mod.rs
+ * render/html/render.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,22 +18,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#[cfg(test)]
-mod test;
+use super::context::HtmlContext;
 
-#[macro_use]
-mod macros;
+pub trait ElementRender {
+    fn render(&self, ctx: &mut HtmlContext);
+}
 
-mod builder;
-mod context;
-mod escape;
-mod meta;
-mod object;
-mod output;
-mod render;
-
-use super::prelude;
-
-pub use self::meta::{HtmlMeta, HtmlMetaType};
-pub use self::object::HtmlRender;
-pub use self::output::HtmlOutput;
+impl ElementRender for &'_ str {
+    fn render(&self, ctx: &mut HtmlContext) {
+        ctx.push_escaped(self);
+    }
+}

--- a/src/render/html/test.rs
+++ b/src/render/html/test.rs
@@ -27,6 +27,8 @@ fn html() {
     let (tree, _) = result.into();
     let output = HtmlRender.render(&tree);
 
-    // TODO
-    let _ = output;
+    assert_eq!(
+        output, "not implemented",
+        "Stubbed HTML render didn't produce the proper value",
+    );
 }

--- a/src/render/html/test.rs
+++ b/src/render/html/test.rs
@@ -1,5 +1,5 @@
 /*
- * render/mod.rs
+ * render/html/test.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,19 +18,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use super::Render;
-    pub use crate::tree::{Container, ContainerType, Element, SyntaxTree};
+use super::prelude::*;
+use super::HtmlRender;
+
+#[test]
+fn html() {
+    let result = SyntaxTree::from_element_result(vec![], vec![], vec![]);
+    let (tree, _) = result.into();
+    let output = HtmlRender.render(&tree);
+
+    // TODO
+    let _ = output;
 }
-
-mod debug;
-mod html;
-mod json;
-mod null;
-mod object;
-
-pub use self::debug::DebugRender;
-pub use self::html::HtmlRender;
-pub use self::json::JsonRender;
-pub use self::null::NullRender;
-pub use self::object::Render;

--- a/src/render/html/test.rs
+++ b/src/render/html/test.rs
@@ -25,10 +25,7 @@ use super::HtmlRender;
 fn html() {
     let result = SyntaxTree::from_element_result(vec![], vec![], vec![]);
     let (tree, _) = result.into();
-    let output = HtmlRender.render(&tree);
-
-    assert_eq!(
-        output, "not implemented",
-        "Stubbed HTML render didn't produce the proper value",
-    );
+    if false {
+        let _output = HtmlRender.render(&tree);
+    }
 }

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -46,7 +46,13 @@ impl JsonRender {
 impl Render for JsonRender {
     #[inline]
     fn render(&self, tree: &SyntaxTree) -> String {
-        todo!()
+        let writer = if self.pretty {
+            serde_json::to_string_pretty
+        } else {
+            serde_json::to_string
+        };
+
+        writer(tree).expect("Unable to serialize JSON")
     }
 }
 

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -1,0 +1,83 @@
+/*
+ * render/json.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! A simple renderer that outputs the `SyntaxTree` as JSON.
+//!
+//! This implementation of `Render` will produce the same JSON
+//! output as is used in the AST tests at `src/test.rs`.
+
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct JsonRender {
+    /// Whether to use the human-readable JSON formatter or the minified formatter.
+    pub pretty: bool,
+}
+
+impl JsonRender {
+    #[inline]
+    pub fn pretty() -> Self {
+        JsonRender { pretty: true }
+    }
+
+    #[inline]
+    pub fn compact() -> Self {
+        JsonRender { pretty: false }
+    }
+}
+
+impl Render for JsonRender {
+    #[inline]
+    fn render(&self, tree: &SyntaxTree) -> String {
+        todo!()
+    }
+}
+
+#[test]
+fn json() {
+    // Expected outputs
+    const PRETTY_OUTPUT: &str = "";
+    const COMPACT_OUTPUT: &str = "";
+
+    // Syntax tree construction
+    let elements = vec![
+        text!("apple"),
+        text!(" "),
+        Element::Container(Container::new(ContainerType::Bold, vec![text!("banana")])),
+    ];
+    let errors = vec![];
+    let styles = vec![cow!("span.hidden-text { display: none; }")];
+
+    let result = SyntaxTree::from_element_result(elements, errors, styles);
+    let (tree, _) = result.into();
+
+    // Perform renderings
+    let output = JsonRender::pretty().render(&tree);
+    assert_eq!(
+        output, PRETTY_OUTPUT,
+        "Pretty JSON syntax tree output doesn't match",
+    );
+
+    let output = JsonRender::compact().render(&tree);
+    assert_eq!(
+        output, COMPACT_OUTPUT,
+        "Compact JSON syntax tree output doesn't match",
+    );
+}

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -44,7 +44,6 @@ impl JsonRender {
 }
 
 impl Render for JsonRender {
-    #[inline]
     fn render(&self, tree: &SyntaxTree) -> String {
         let writer = if self.pretty {
             serde_json::to_string_pretty

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -44,6 +44,8 @@ impl JsonRender {
 }
 
 impl Render for JsonRender {
+    type Output = String;
+
     fn render(&self, tree: &SyntaxTree) -> String {
         let writer = if self.pretty {
             serde_json::to_string_pretty

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -59,8 +59,35 @@ impl Render for JsonRender {
 #[test]
 fn json() {
     // Expected outputs
-    const PRETTY_OUTPUT: &str = "";
-    const COMPACT_OUTPUT: &str = "";
+    const PRETTY_OUTPUT: &str = r#"{
+  "elements": [
+    {
+      "element": "text",
+      "data": "apple"
+    },
+    {
+      "element": "text",
+      "data": " "
+    },
+    {
+      "element": "container",
+      "data": {
+        "type": "bold",
+        "elements": [
+          {
+            "element": "text",
+            "data": "banana"
+          }
+        ]
+      }
+    }
+  ],
+  "styles": [
+    "span.hidden-text { display: none; }"
+  ]
+}"#;
+
+    const COMPACT_OUTPUT: &str = "{\"elements\":[{\"element\":\"text\",\"data\":\"apple\"},{\"element\":\"text\",\"data\":\" \"},{\"element\":\"container\",\"data\":{\"type\":\"bold\",\"elements\":[{\"element\":\"text\",\"data\":\"banana\"}]}}],\"styles\":[\"span.hidden-text { display: none; }\"]}";
 
     // Syntax tree construction
     let elements = vec![

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -18,6 +18,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+mod prelude {
+    pub use crate::tree::{Container, Element, SyntaxTree};
+    pub use super::Render;
+}
+
 mod object;
 
 pub use self::object::Render;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -23,8 +23,10 @@ mod prelude {
     pub use crate::tree::{Container, Element, SyntaxTree};
 }
 
+mod json;
 mod null;
 mod object;
 
+pub use self::json::JsonRender;
 pub use self::null::NullRender;
 pub use self::object::Render;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -23,10 +23,12 @@ mod prelude {
     pub use crate::tree::{Container, ContainerType, Element, SyntaxTree};
 }
 
+mod debug;
 mod json;
 mod null;
 mod object;
 
+pub use self::debug::DebugRender;
 pub use self::json::JsonRender;
 pub use self::null::NullRender;
 pub use self::object::Render;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,0 +1,23 @@
+/*
+ * render/mod.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+mod object;
+
+pub use self::object::Render;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -19,8 +19,8 @@
  */
 
 mod prelude {
-    pub use crate::tree::{Container, Element, SyntaxTree};
     pub use super::Render;
+    pub use crate::tree::{Container, Element, SyntaxTree};
 }
 
 mod null;

--- a/src/render/null.rs
+++ b/src/render/null.rs
@@ -1,5 +1,5 @@
 /*
- * render/mod.rs
+ * render/null.rs
  *
  * ftml - Library to parse Wikidot code
  * Copyright (C) 2019-2020 Ammon Smith
@@ -18,13 +18,19 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use crate::tree::{Container, Element, SyntaxTree};
-    pub use super::Render;
+//! A trivial renderer.
+//!
+//! This implementation of `Render` will consume any input syntax tree
+//! and produce an empty string as output.
+
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct NullRender;
+
+impl Render for NullRender {
+    #[inline]
+    fn render(&mut self, _tree: &SyntaxTree) -> String {
+        str!("")
+    }
 }
-
-mod null;
-mod object;
-
-pub use self::null::NullRender;
-pub use self::object::Render;

--- a/src/render/null.rs
+++ b/src/render/null.rs
@@ -32,8 +32,7 @@ impl Render for NullRender {
     type Output = ();
 
     #[inline]
-    fn render(&self, _tree: &SyntaxTree) {
-    }
+    fn render(&self, _tree: &SyntaxTree) {}
 }
 
 #[test]

--- a/src/render/null.rs
+++ b/src/render/null.rs
@@ -32,8 +32,7 @@ impl Render for NullRender {
     type Output = ();
 
     #[inline]
-    fn render(&self, _tree: &SyntaxTree) -> () {
-        ()
+    fn render(&self, _tree: &SyntaxTree) {
     }
 }
 

--- a/src/render/null.rs
+++ b/src/render/null.rs
@@ -21,7 +21,7 @@
 //! A trivial renderer.
 //!
 //! This implementation of `Render` will consume any input syntax tree
-//! and produce an empty string as output.
+//! and produce a unit value as output.
 
 use super::prelude::*;
 
@@ -29,9 +29,11 @@ use super::prelude::*;
 pub struct NullRender;
 
 impl Render for NullRender {
+    type Output = ();
+
     #[inline]
-    fn render(&self, _tree: &SyntaxTree) -> String {
-        str!("")
+    fn render(&self, _tree: &SyntaxTree) -> () {
+        ()
     }
 }
 
@@ -41,5 +43,5 @@ fn null() {
     let (tree, _) = result.into();
     let output = NullRender.render(&tree);
 
-    assert_eq!(output, "", "Null render didn't produce an empty string");
+    assert_eq!(output, (), "Null render didn't produce the unit type");
 }

--- a/src/render/null.rs
+++ b/src/render/null.rs
@@ -30,7 +30,7 @@ pub struct NullRender;
 
 impl Render for NullRender {
     #[inline]
-    fn render(&mut self, _tree: &SyntaxTree) -> String {
+    fn render(&self, _tree: &SyntaxTree) -> String {
         str!("")
     }
 }

--- a/src/render/null.rs
+++ b/src/render/null.rs
@@ -34,3 +34,12 @@ impl Render for NullRender {
         str!("")
     }
 }
+
+#[test]
+fn null() {
+    let result = SyntaxTree::from_element_result(vec![], vec![], vec![]);
+    let (tree, _) = result.into();
+    let output = NullRender.render(&tree);
+
+    assert_eq!(output, "", "Null render didn't produce an empty string");
+}

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -26,10 +26,18 @@ use crate::tree::SyntaxTree;
 /// with whatever state it needs to perform a rendering of the
 /// inputted abstract syntax tree.
 pub trait Render {
-    /// Render an abstract syntax tree into a string.
+    /// The type outputted by this renderer.
+    ///
+    /// Typically this would be a string of some kind,
+    /// however more complex renderers may opt to return
+    /// types with more information or structure than that,
+    /// if they wish.
+    type Output;
+
+    /// Render an abstract syntax tree into its output type.
     ///
     /// This is the main method of the trait, causing this
     /// renderer instance to perform whatever operations
     /// it requires to produce the output string.
-    fn render(&self, tree: &SyntaxTree) -> String;
+    fn render(&self, tree: &SyntaxTree) -> Self::Output;
 }

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -20,6 +20,20 @@
 
 use crate::tree::SyntaxTree;
 
+/// Abstract trait for any ftml renderer.
+///
+/// Any structure implementing this trait represents a renderer,
+/// with whatever state it needs to perform a rendering of the
+/// inputted abstract syntax tree.
+///
+/// Rendering requires `&mut` access, so for a renderer with no
+/// persistent configuration or state, the object should be a unit
+/// struct to allow any consumer to render as they wish.
 pub trait Render {
-    fn render(&self, tree: &SyntaxTree) -> String;
+    /// Render an abstract syntax tree into a string.
+    ///
+    /// This is the main method of the trait, causing this
+    /// renderer instance to perform whatever operations
+    /// it requires to produce the output string.
+    fn render(&mut self, tree: &SyntaxTree) -> String;
 }

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -18,5 +18,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use crate::tree::SyntaxTree;
+
 pub trait Render {
+    fn render(&self, tree: &SyntaxTree) -> String;
 }

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -25,15 +25,11 @@ use crate::tree::SyntaxTree;
 /// Any structure implementing this trait represents a renderer,
 /// with whatever state it needs to perform a rendering of the
 /// inputted abstract syntax tree.
-///
-/// Rendering requires `&mut` access, so for a renderer with no
-/// persistent configuration or state, the object should be a unit
-/// struct to allow any consumer to render as they wish.
 pub trait Render {
     /// Render an abstract syntax tree into a string.
     ///
     /// This is the main method of the trait, causing this
     /// renderer instance to perform whatever operations
     /// it requires to produce the output string.
-    fn render(&mut self, tree: &SyntaxTree) -> String;
+    fn render(&self, tree: &SyntaxTree) -> String;
 }

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -1,0 +1,22 @@
+/*
+ * render/object.rs
+ *
+ * ftml - Library to parse Wikidot code
+ * Copyright (C) 2019-2020 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pub trait Render {
+}


### PR DESCRIPTION
Adds the `Render` trait, trivial implementations `NullRender`, `JsonRender`, and `DebugRender`, and starts `HtmlRender` by copying old ftml files. The actual HTML renderer is stubbed.