### PR TITLE
Preserve errors from failed rules

### DIFF
--- a/src/parse/consume.rs
+++ b/src/parse/consume.rs
@@ -83,6 +83,13 @@ pub fn consume<'r, 't>(
 
     debug!(log, "All rules exhausted, using generic text fallback");
 
+    trace!(log, "Removing non-errors from exceptions list");
+
+    // We should only carry styles over from *successful* consumptions
+    all_exceptions.retain(|exception| matches!(exception, ParseException::Error(_)));
+
+    trace!(log, "Adding fallback error to exceptions list");
+
     all_exceptions.push(ParseException::Error(ParseError::new(
         ParseErrorKind::NoRulesMatch,
         RULE_FALLBACK,

--- a/src/parse/consume.rs
+++ b/src/parse/consume.rs
@@ -31,6 +31,7 @@ use super::token::ExtractedToken;
 use super::{ParseError, ParseErrorKind, ParseException};
 use crate::text::FullText;
 use crate::tree::Element;
+use std::mem;
 
 /// Main function that consumes tokens to produce a single element, then returns.
 pub fn consume<'r, 't>(
@@ -58,6 +59,13 @@ pub fn consume<'r, 't>(
         let consumption = rule.try_consume(log, extracted, remaining, full_text);
         if consumption.is_success() {
             debug!(log, "Rule matched, returning generated result"; "rule" => rule);
+
+            // Explicitly drop exceptions
+            //
+            // We're returning the successful consumption
+            // so these are going to be dropped as a previously
+            // unsuccessful attempts.
+            mem::drop(all_exceptions);
 
             return consumption;
         }

--- a/src/parse/rule/impls/color.rs
+++ b/src/parse/rule/impls/color.rs
@@ -53,7 +53,7 @@ fn try_consume_fn<'r, 't>(
     );
 
     // Return if failure, and get last token for try_container()
-    let (color, extracted, remaining, mut all_errors) =
+    let (color, extracted, remaining, mut all_exceptions) =
         try_consume_last!(remaining, consumption);
 
     debug!(
@@ -74,10 +74,10 @@ fn try_consume_fn<'r, 't>(
     );
 
     // Append errors, or return if failure
-    let (elements, remaining, mut errors) = try_consume!(consumption);
+    let (elements, remaining, mut exceptions) = try_consume!(consumption);
 
     // Add on new errors
-    all_errors.append(&mut errors);
+    all_exceptions.append(&mut exceptions);
 
     // Return result
     let element = Element::Color {
@@ -85,5 +85,5 @@ fn try_consume_fn<'r, 't>(
         elements,
     };
 
-    Consumption::warn(element, remaining, all_errors)
+    Consumption::warn(element, remaining, all_exceptions)
 }

--- a/src/parse/rule/impls/link_anchor.rs
+++ b/src/parse/rule/impls/link_anchor.rs
@@ -52,7 +52,7 @@ fn try_consume_fn<'r, 't>(
     );
 
     // Return if failure, and get last token for try_merge()
-    let (url, extracted, remaining, mut all_errors) =
+    let (url, extracted, remaining, mut all_exceptions) =
         try_consume_last!(remaining, consumption);
 
     // Determine if this is an anchor link or fake link
@@ -78,7 +78,7 @@ fn try_consume_fn<'r, 't>(
     );
 
     // Append errors, or return if failure
-    let (label, remaining, mut errors) = try_consume!(consumption);
+    let (label, remaining, mut exceptions) = try_consume!(consumption);
 
     debug!(
         log,
@@ -89,8 +89,8 @@ fn try_consume_fn<'r, 't>(
     // Trimming label
     let label = label.trim();
 
-    // Add on new errors
-    all_errors.append(&mut errors);
+    // Add on new exceptions
+    all_exceptions.append(&mut exceptions);
 
     // Build link element
     let element = Element::Link {
@@ -100,5 +100,5 @@ fn try_consume_fn<'r, 't>(
     };
 
     // Return result
-    Consumption::warn(element, remaining, all_errors)
+    Consumption::warn(element, remaining, all_exceptions)
 }

--- a/src/parse/rule/impls/link_single.rs
+++ b/src/parse/rule/impls/link_single.rs
@@ -95,7 +95,7 @@ fn try_consume_link<'r, 't>(
     );
 
     // Return if failure, and get last token for try_merge()
-    let (url, extracted, remaining, mut all_errors) =
+    let (url, extracted, remaining, mut all_exceptions) =
         try_consume_last!(remaining, consumption);
 
     if !url_valid(url) {
@@ -123,7 +123,7 @@ fn try_consume_link<'r, 't>(
     );
 
     // Append errors, or return if failure
-    let (label, remaining, mut errors) = try_consume!(consumption);
+    let (label, remaining, mut exceptions) = try_consume!(consumption);
 
     debug!(
         log,
@@ -135,7 +135,7 @@ fn try_consume_link<'r, 't>(
     let label = label.trim();
 
     // Add on new errors
-    all_errors.append(&mut errors);
+    all_exceptions.append(&mut exceptions);
 
     // Build link element
     let element = Element::Link {
@@ -145,7 +145,7 @@ fn try_consume_link<'r, 't>(
     };
 
     // Return result
-    Consumption::warn(element, remaining, all_errors)
+    Consumption::warn(element, remaining, all_exceptions)
 }
 
 fn url_valid(url: &str) -> bool {

--- a/test/bold-fail-paragraph.json
+++ b/test/bold-fail-paragraph.json
@@ -40,10 +40,22 @@
     },
     "errors": [
         {
+            "token": "paragraph-break",
+            "rule": "bold",
+            "span": [6, 8],
+            "kind": "rule-failed"
+        },
+        {
             "token": "bold",
             "rule": "fallback",
             "span": [0, 2],
             "kind": "no-rules-match"
+        },
+        {
+            "token": "input-end",
+            "rule": "bold",
+            "span": [14, 14],
+            "kind": "rule-failed"
         },
         {
             "token": "bold",

--- a/test/bold-fail.json
+++ b/test/bold-fail.json
@@ -32,6 +32,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "bold",
+            "span": [11, 11],
+            "kind": "rule-failed"
+        },
+        {
             "token": "bold",
             "rule": "fallback",
             "span": [0, 2],

--- a/test/color-fail.json
+++ b/test/color-fail.json
@@ -32,6 +32,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "color",
+            "span": [11, 11],
+            "kind": "rule-failed"
+        },
+        {
             "token": "color",
             "rule": "fallback",
             "span": [0, 2],

--- a/test/comment-fail-left.json
+++ b/test/comment-fail-left.json
@@ -36,6 +36,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "comment",
+            "span": [17, 17],
+            "kind": "end-of-input"
+        },
+        {
             "token": "left-comment",
             "rule": "fallback",
             "span": [5, 9],

--- a/test/italics-fail-paragraph.json
+++ b/test/italics-fail-paragraph.json
@@ -40,10 +40,22 @@
     },
     "errors": [
         {
+            "token": "paragraph-break",
+            "rule": "italics",
+            "span": [6, 8],
+            "kind": "rule-failed"
+        },
+        {
             "token": "italics",
             "rule": "fallback",
             "span": [0, 2],
             "kind": "no-rules-match"
+        },
+        {
+            "token": "input-end",
+            "rule": "italics",
+            "span": [17, 17],
+            "kind": "rule-failed"
         },
         {
             "token": "italics",

--- a/test/italics-fail.json
+++ b/test/italics-fail.json
@@ -32,6 +32,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "italics",
+            "span": [14, 14],
+            "kind": "rule-failed"
+        },
+        {
             "token": "italics",
             "rule": "fallback",
             "span": [0, 2],

--- a/test/link-anchor-fail.json
+++ b/test/link-anchor-fail.json
@@ -1,0 +1,37 @@
+{
+    "input": "[# Label",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "[#"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "Label"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "errors": [
+        {
+            "token": "left-bracket-anchor",
+            "rule": "fallback",
+            "span": [0, 2],
+            "kind": "no-rules-match"
+        }
+    ]
+}

--- a/test/link-anchor-fail.json
+++ b/test/link-anchor-fail.json
@@ -28,6 +28,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "link-anchor",
+            "span": [8, 8],
+            "kind": "rule-failed"
+        },
+        {
             "token": "left-bracket-anchor",
             "rule": "fallback",
             "span": [0, 2],

--- a/test/link-single-fail-new-tab.json
+++ b/test/link-single-fail-new-tab.json
@@ -52,6 +52,12 @@
     },
     "errors": [
         {
+            "token": "whitespace",
+            "rule": "link-single-new-tab",
+            "span": [2, 3],
+            "kind": "invalid-url"
+        },
+        {
             "token": "left-bracket-special",
             "rule": "fallback",
             "span": [0, 2],

--- a/test/link-triple-fail-brackets-left.json
+++ b/test/link-triple-fail-brackets-left.json
@@ -32,6 +32,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "link-triple",
+            "span": [12, 12],
+            "kind": "rule-failed"
+        },
+        {
             "token": "left-link",
             "rule": "fallback",
             "span": [0, 3],

--- a/test/link-triple-fail-newline.json
+++ b/test/link-triple-fail-newline.json
@@ -55,6 +55,12 @@
     },
     "errors": [
         {
+            "token": "line-break",
+            "rule": "link-triple",
+            "span": [14, 15],
+            "kind": "rule-failed"
+        },
+        {
             "token": "left-link",
             "rule": "fallback",
             "span": [0, 3],

--- a/test/link-triple-fail-title-new-tab.json
+++ b/test/link-triple-fail-title-new-tab.json
@@ -40,6 +40,12 @@
     },
     "errors": [
         {
+            "token": "pipe",
+            "rule": "link-triple-new-tab",
+            "span": [4, 5],
+            "kind": "rule-failed"
+        },
+        {
             "token": "left-link-special",
             "rule": "fallback",
             "span": [0, 4],

--- a/test/link-triple-fail-title.json
+++ b/test/link-triple-fail-title.json
@@ -40,6 +40,12 @@
     },
     "errors": [
         {
+            "token": "pipe",
+            "rule": "link-triple",
+            "span": [3, 4],
+            "kind": "rule-failed"
+        },
+        {
             "token": "left-link",
             "rule": "fallback",
             "span": [0, 3],

--- a/test/monospace-fail-left.json
+++ b/test/monospace-fail-left.json
@@ -32,6 +32,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "monospace",
+            "span": [16, 16],
+            "kind": "rule-failed"
+        },
+        {
             "token": "left-monospace",
             "rule": "fallback",
             "span": [0, 2],

--- a/test/monospace-fail-paragraph.json
+++ b/test/monospace-fail-paragraph.json
@@ -40,6 +40,12 @@
     },
     "errors": [
         {
+            "token": "paragraph-break",
+            "rule": "monospace",
+            "span": [6, 8],
+            "kind": "rule-failed"
+        },
+        {
             "token": "left-monospace",
             "rule": "fallback",
             "span": [0, 2],

--- a/test/raw-fail-newline-angles.json
+++ b/test/raw-fail-newline-angles.json
@@ -35,6 +35,12 @@
     },
     "errors": [
         {
+            "token": "line-break",
+            "rule": "raw",
+            "span": [14, 15],
+            "kind": "rule-failed"
+        },
+        {
             "token": "left-raw",
             "rule": "fallback",
             "span": [12, 14],

--- a/test/raw-fail-newline.json
+++ b/test/raw-fail-newline.json
@@ -35,10 +35,22 @@
     },
     "errors": [
         {
+            "token": "line-break",
+            "rule": "raw",
+            "span": [14, 15],
+            "kind": "rule-failed"
+        },
+        {
             "token": "raw",
             "rule": "fallback",
             "span": [12, 14],
             "kind": "no-rules-match"
+        },
+        {
+            "token": "raw",
+            "rule": "raw",
+            "span": [15, 17],
+            "kind": "end-of-input"
         },
         {
             "token": "raw",

--- a/test/raw-fail-paragraph.json
+++ b/test/raw-fail-paragraph.json
@@ -40,10 +40,22 @@
     },
     "errors": [
         {
+            "token": "paragraph-break",
+            "rule": "raw",
+            "span": [6, 8],
+            "kind": "rule-failed"
+        },
+        {
             "token": "raw",
             "rule": "fallback",
             "span": [0, 2],
             "kind": "no-rules-match"
+        },
+        {
+            "token": "raw",
+            "rule": "raw",
+            "span": [11, 13],
+            "kind": "end-of-input"
         },
         {
             "token": "raw",

--- a/test/subscript-fail.json
+++ b/test/subscript-fail.json
@@ -32,6 +32,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "subscript",
+            "span": [16, 16],
+            "kind": "rule-failed"
+        },
+        {
             "token": "subscript",
             "rule": "fallback",
             "span": [0, 2],

--- a/test/superscript-fail.json
+++ b/test/superscript-fail.json
@@ -32,6 +32,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "superscript",
+            "span": [18, 18],
+            "kind": "rule-failed"
+        },
+        {
             "token": "superscript",
             "rule": "fallback",
             "span": [0, 2],

--- a/test/underline-fail-paragraph.json
+++ b/test/underline-fail-paragraph.json
@@ -40,10 +40,22 @@
     },
     "errors": [
         {
+            "token": "paragraph-break",
+            "rule": "underline",
+            "span": [6, 8],
+            "kind": "rule-failed"
+        },
+        {
             "token": "underline",
             "rule": "fallback",
             "span": [0, 2],
             "kind": "no-rules-match"
+        },
+        {
+            "token": "input-end",
+            "rule": "underline",
+            "span": [19, 19],
+            "kind": "rule-failed"
         },
         {
             "token": "underline",

--- a/test/underline-fail.json
+++ b/test/underline-fail.json
@@ -32,6 +32,12 @@
     },
     "errors": [
         {
+            "token": "input-end",
+            "rule": "underline",
+            "span": [16, 16],
+            "kind": "rule-failed"
+        },
+        {
             "token": "underline",
             "rule": "fallback",
             "span": [0, 2],


### PR DESCRIPTION
We want to see all errors from rules, not just the fallback ones, as it aids in understanding what's wrong with the code. Previously this was discarded incorrectly.

However we still need to discard styles as those can only come from successful consumptions.