### PR TITLE
Rename parse "errors" to "warnings"

### DIFF
--- a/Philosophy.md
+++ b/Philosophy.md
@@ -14,7 +14,7 @@ but the parser is hand-written to allow for loose fallback rules.
 
 More specifically, for each encountered token, the parser will attempt to match the first rule
 which expects it. Incoming tokens will be handled, producing elements, or until an invalid token
-is received, at which point an "error" will be produced and this rule will abort.
+is received, at which point a "warning" will be produced and this rule will abort.
 
 Following this, the parser will attempt to apply the second rule (if any), etc., until all rules are
 exhausted. At this point, if no match can be made, the default "fallback" rule is applied. This is
@@ -25,11 +25,12 @@ is bumped up (really, a later subslice is taken), and the element is appended to
 Note that this operation is applied recursively, so that any containers (elements which contain other
 elements) will perform this same operation to populate themselves.
 
-It is important to note that, in accordance to the Wikidot parsing strategy, all "errors" are non-fatal.
+In accordance to the Wikidot parsing strategy, all "warnings" are non-fatal. (These were previously named
+"errors" but were renamed in [#103](https://github.com/Nu-SCPTheme/ftml/pull/103) for clarity).
 In the worst-case scenario, all tokens fail all rules, and all are parsed with the fallback, rule, producing
-an error for each incident. In a more typical case, any invalid structures will produce errors, and will
+a warning for each incident. In a more typical case, any invalid structures will produce warning, and will
 parsed as best it can.
 
-These errors are returned to the caller to provide information on where the process failed, while still
-producing the fallback render. This provides the both of best worlds: errors to assist with wikitext
-debugging, but also not hard-failing rendering in case of any error.
+These warnings are returned to the caller to provide information on where the process failed, while still
+producing the fallback render. This provides the both of best worlds: warnings to assist with wikitext
+debugging, but also not hard-failing rendering in case of one.

--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ let tokens = ftml::tokenize(&log, &text);
 // Parse the token list to produce an AST.
 //
 // Note that this produces a `ParseResult<SyntaxTree>`, which records the
-// parsing errors in addition to the final result.
+// parsing warnings in addition to the final result.
 let result = ftml::parse(&log, &tokens);
 
-// Here we extract the tree separately from the error list.
+// Here we extract the tree separately from the warning list.
 //
 // Now we have the final AST, as well as all the issues that
 // occurred during the parsing process.
-let (tree, errors) = result.into();
+let (tree, warnings) = result.into();
 ```
 
 ### JSON Serialization

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub mod tree;
 pub use self::log::{build_console_logger, build_logger, build_null_logger};
 
 pub use self::parse::{
-    parse, ExtractedToken, ParseError, ParseErrorKind, ParseOutcome, Token,
+    parse, ExtractedToken, ParseOutcome, ParseWarning, ParseWarningKind, Token,
 };
 pub use self::preproc::preprocess;
 pub use self::render::*;

--- a/src/parse/check_step.rs
+++ b/src/parse/check_step.rs
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::{ParseError, Parser, Token};
+use super::{ParseWarning, Parser, Token};
 
 /// Helper function to assert that the current token matches, then step.
 ///
@@ -26,7 +26,7 @@ use super::{ParseError, Parser, Token};
 /// Since an assert is used, this function will panic
 /// if the extracted token does not match the one specified.
 #[inline]
-pub fn check_step(parser: &mut Parser, token: Token) -> Result<(), ParseError> {
+pub fn check_step(parser: &mut Parser, token: Token) -> Result<(), ParseWarning> {
     assert_eq!(
         parser.current().token,
         token,

--- a/src/parse/collect/consume.rs
+++ b/src/parse/collect/consume.rs
@@ -32,7 +32,7 @@ pub fn collect_consume<'p, 'r, 't>(
     rule: Rule,
     close_conditions: &[ParseCondition],
     invalid_conditions: &[ParseCondition],
-    error_kind: Option<ParseErrorKind>,
+    warn_kind: Option<ParseWarningKind>,
 ) -> ParseResult<'r, 't, Vec<Element<'t>>> {
     let mut elements = Vec::new();
 
@@ -42,7 +42,7 @@ pub fn collect_consume<'p, 'r, 't>(
         rule,
         close_conditions,
         invalid_conditions,
-        error_kind,
+        warn_kind,
         |log, parser| {
             consume(log, parser)?.map_ok(|element| {
                 if element != Element::Null {

--- a/src/parse/collect/container.rs
+++ b/src/parse/collect/container.rs
@@ -45,7 +45,7 @@ pub fn collect_container<'p, 'r, 't>(
     container_type: ContainerType,
     close_conditions: &[ParseCondition],
     invalid_conditions: &[ParseCondition],
-    error_kind: Option<ParseErrorKind>,
+    warn_kind: Option<ParseWarningKind>,
 ) -> ParseResult<'r, 't, Element<'t>> {
     // Log collect_container() call
     let log = &log.new(slog_o!(
@@ -65,7 +65,7 @@ pub fn collect_container<'p, 'r, 't>(
         rule,
         close_conditions,
         invalid_conditions,
-        error_kind,
+        warn_kind,
     )?
     .into();
 

--- a/src/parse/collect/generic.rs
+++ b/src/parse/collect/generic.rs
@@ -44,12 +44,12 @@ use crate::span_wrap::SpanWrap;
 /// If one of these is true, we will return failure.
 /// * `invalid_conditions`
 ///
-/// If one of the failures is activated, then this `ParseErrorKind`
-/// will be returned. If `None` is provided, then `ParseErrorKind::RuleFailed` is used.
-/// * `error_kind`
+/// If one of the failures is activated, then this `ParseWarningKind`
+/// will be returned. If `None` is provided, then `ParseWarningKind::RuleFailed` is used.
+/// * `warn_kind`
 ///
 /// The closure we should execute each time a token extraction is reached:
-/// If the return value is `Err(_)` then collection is aborted and that error
+/// If the return value is `Err(_)` then collection is aborted and that warning
 /// is bubbled up.
 /// * `process`
 ///
@@ -67,7 +67,7 @@ pub fn collect<'p, 'r, 't, F>(
     rule: Rule,
     close_conditions: &[ParseCondition],
     invalid_conditions: &[ParseCondition],
-    error_kind: Option<ParseErrorKind>,
+    warn_kind: Option<ParseWarningKind>,
     mut process: F,
 ) -> ParseResult<'r, 't, &'r ExtractedToken<'t>>
 where
@@ -102,7 +102,7 @@ where
         if parser.current().token == Token::InputEnd {
             debug!(log, "Found end of input, aborting");
 
-            return Err(parser.make_error(ParseErrorKind::EndOfInput));
+            return Err(parser.make_warn(ParseWarningKind::EndOfInput));
         }
 
         // See if the container has ended
@@ -128,7 +128,7 @@ where
             );
 
             return Err(
-                parser.make_error(error_kind.unwrap_or(ParseErrorKind::RuleFailed))
+                parser.make_warn(warn_kind.unwrap_or(ParseWarningKind::RuleFailed))
             );
         }
 

--- a/src/parse/collect/mod.rs
+++ b/src/parse/collect/mod.rs
@@ -30,7 +30,7 @@ mod prelude {
     pub use super::collect;
     pub use crate::parse::condition::ParseCondition;
     pub use crate::parse::consume::consume;
-    pub use crate::parse::error::{ParseError, ParseErrorKind};
+    pub use crate::parse::exception::{ParseWarning, ParseWarningKind};
     pub use crate::parse::parser::Parser;
     pub use crate::parse::prelude::*;
     pub use crate::parse::rule::Rule;

--- a/src/parse/collect/text.rs
+++ b/src/parse/collect/text.rs
@@ -32,8 +32,8 @@ pub fn collect_text<'p, 'r, 't>(
     rule: Rule,
     close_conditions: &[ParseCondition],
     invalid_conditions: &[ParseCondition],
-    error_kind: Option<ParseErrorKind>,
-) -> Result<&'t str, ParseError>
+    warn_kind: Option<ParseWarningKind>,
+) -> Result<&'t str, ParseWarning>
 where
     'r: 't,
 {
@@ -43,7 +43,7 @@ where
         rule,
         close_conditions,
         invalid_conditions,
-        error_kind,
+        warn_kind,
     )
     .map(|(slice, _)| slice)
 }
@@ -58,8 +58,8 @@ pub fn collect_text_keep<'p, 'r, 't>(
     rule: Rule,
     close_conditions: &[ParseCondition],
     invalid_conditions: &[ParseCondition],
-    error_kind: Option<ParseErrorKind>,
-) -> Result<(&'t str, &'r ExtractedToken<'t>), ParseError>
+    warn_kind: Option<ParseWarningKind>,
+) -> Result<(&'t str, &'r ExtractedToken<'t>), ParseWarning>
 where
     'r: 't,
 {
@@ -78,7 +78,7 @@ where
         rule,
         close_conditions,
         invalid_conditions,
-        error_kind,
+        warn_kind,
         |log, parser| {
             trace!(log, "Ingesting token in string span");
 

--- a/src/parse/consume.rs
+++ b/src/parse/consume.rs
@@ -74,8 +74,8 @@ pub fn consume<'p, 'r, 't>(
 
                 return Ok(output);
             }
-            Err(error) => {
-                all_exceptions.push(ParseException::Error(error));
+            Err(warning) => {
+                all_exceptions.push(ParseException::Warning(warning));
             }
         }
     }
@@ -85,12 +85,12 @@ pub fn consume<'p, 'r, 't>(
     parser.step()?;
 
     // We should only carry styles over from *successful* consumptions
-    trace!(log, "Removing non-errors from exceptions list");
-    all_exceptions.retain(|exception| matches!(exception, ParseException::Error(_)));
+    trace!(log, "Removing non-warnings from exceptions list");
+    all_exceptions.retain(|exception| matches!(exception, ParseException::Warning(_)));
 
-    trace!(log, "Adding fallback error to exceptions list");
-    all_exceptions.push(ParseException::Error(ParseError::new(
-        ParseErrorKind::NoRulesMatch,
+    trace!(log, "Adding fallback warning to exceptions list");
+    all_exceptions.push(ParseException::Warning(ParseWarning::new(
+        ParseWarningKind::NoRulesMatch,
         RULE_FALLBACK,
         current,
     )));

--- a/src/parse/outcome.rs
+++ b/src/parse/outcome.rs
@@ -18,24 +18,24 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::ParseError;
+use super::ParseWarning;
 use std::borrow::{Borrow, BorrowMut};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ParseOutcome<T> {
     value: T,
-    errors: Vec<ParseError>,
+    warnings: Vec<ParseWarning>,
 }
 
 impl<T> ParseOutcome<T> {
     #[inline]
-    pub fn new<I>(value: T, errors: I) -> Self
+    pub fn new<I>(value: T, warnings: I) -> Self
     where
-        I: Into<Vec<ParseError>>,
+        I: Into<Vec<ParseWarning>>,
     {
         ParseOutcome {
             value,
-            errors: errors.into(),
+            warnings: warnings.into(),
         }
     }
 
@@ -46,8 +46,8 @@ impl<T> ParseOutcome<T> {
     }
 
     #[inline]
-    pub fn errors(&self) -> &[ParseError] {
-        &self.errors
+    pub fn warnings(&self) -> &[ParseWarning] {
+        &self.warnings
     }
 }
 
@@ -66,7 +66,7 @@ where
     fn clone(&self) -> Self {
         ParseOutcome {
             value: self.value.clone(),
-            errors: self.errors.clone(),
+            warnings: self.warnings.clone(),
         }
     }
 }
@@ -79,7 +79,7 @@ where
     fn default() -> Self {
         ParseOutcome {
             value: T::default(),
-            errors: Vec::new(),
+            warnings: Vec::new(),
         }
     }
 }
@@ -98,11 +98,11 @@ impl<T> BorrowMut<T> for ParseOutcome<T> {
     }
 }
 
-impl<T> From<ParseOutcome<T>> for (T, Vec<ParseError>) {
+impl<T> From<ParseOutcome<T>> for (T, Vec<ParseWarning>) {
     #[inline]
-    fn from(outcome: ParseOutcome<T>) -> (T, Vec<ParseError>) {
-        let ParseOutcome { value, errors } = outcome;
+    fn from(outcome: ParseOutcome<T>) -> (T, Vec<ParseWarning>) {
+        let ParseOutcome { value, warnings } = outcome;
 
-        (value, errors)
+        (value, warnings)
     }
 }

--- a/src/parse/paragraph.rs
+++ b/src/parse/paragraph.rs
@@ -34,7 +34,7 @@ use super::token::Token;
 /// it's just clarifying what the `_` in `Option<_>` is.
 pub const NO_CLOSE_CONDITION: Option<CloseConditionFn> = None;
 
-type CloseConditionFn = fn(&mut Parser) -> Result<bool, ParseError>;
+type CloseConditionFn = fn(&mut Parser) -> Result<bool, ParseWarning>;
 
 /// Function to iterate over tokens to produce elements in paragraphs.
 ///
@@ -49,7 +49,7 @@ pub fn gather_paragraphs<'r, 't, F>(
 ) -> ParseResult<'r, 't, Vec<Element<'t>>>
 where
     'r: 't,
-    F: FnMut(&mut Parser<'r, 't>) -> Result<bool, ParseError>,
+    F: FnMut(&mut Parser<'r, 't>) -> Result<bool, ParseWarning>,
 {
     info!(log, "Gathering paragraphs until ending");
 
@@ -66,14 +66,14 @@ where
                     // There was a close condition, but it was not satisfied
                     // before the end of input.
                     //
-                    // Pass an error up the chain
+                    // Pass a warning up the chain
 
-                    debug!(log, "Hit the end of input, producing error");
+                    debug!(log, "Hit the end of input, producing warning");
 
-                    return Err(parser.make_error(ParseErrorKind::EndOfInput));
+                    return Err(parser.make_warn(ParseWarningKind::EndOfInput));
                 } else {
                     // Avoid an unnecessary Element::Null and just exit
-                    // If there's no close condition, then this is not an error
+                    // If there's no close condition, then this is not a warning
 
                     debug!(log, "Hit the end of input, terminating token iteration");
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -153,7 +153,7 @@ impl<'r, 't> Parser<'r, 't> {
     #[inline]
     pub fn evaluate_fn<F>(&self, f: F) -> bool
     where
-        F: FnOnce(&mut Parser<'r, 't>) -> Result<bool, ParseError>,
+        F: FnOnce(&mut Parser<'r, 't>) -> Result<bool, ParseWarning>,
     {
         debug!(&self.log, "Evaluating closure for parser condition");
 
@@ -162,7 +162,7 @@ impl<'r, 't> Parser<'r, 't> {
 
     pub fn save_evaluate_fn<F>(&mut self, f: F) -> Option<&'r ExtractedToken<'t>>
     where
-        F: FnOnce(&mut Parser<'r, 't>) -> Result<bool, ParseError>,
+        F: FnOnce(&mut Parser<'r, 't>) -> Result<bool, ParseWarning>,
     {
         debug!(
             &self.log,
@@ -203,7 +203,7 @@ impl<'r, 't> Parser<'r, 't> {
 
     /// Move the token pointer forward one step.
     #[inline]
-    pub fn step(&mut self) -> Result<&'r ExtractedToken<'t>, ParseError> {
+    pub fn step(&mut self) -> Result<&'r ExtractedToken<'t>, ParseWarning> {
         debug!(self.log, "Stepping to the next token");
 
         match self.remaining.split_first() {
@@ -214,13 +214,13 @@ impl<'r, 't> Parser<'r, 't> {
             }
 
             #[cold]
-            None => Err(self.make_error(ParseErrorKind::EndOfInput)),
+            None => Err(self.make_warn(ParseWarningKind::EndOfInput)),
         }
     }
 
     /// Move the token pointer forward `count` steps.
     #[inline]
-    pub fn step_n(&mut self, count: usize) -> Result<(), ParseError> {
+    pub fn step_n(&mut self, count: usize) -> Result<(), ParseWarning> {
         trace!(self.log, "Stepping n times"; "count" => count);
 
         for _ in 0..count {
@@ -240,20 +240,20 @@ impl<'r, 't> Parser<'r, 't> {
         self.remaining.get(offset)
     }
 
-    /// Like `look_ahead`, except returns an error if the token isn't found.
+    /// Like `look_ahead`, except returns a warning if the token isn't found.
     #[inline]
-    pub fn look_ahead_error(
+    pub fn look_ahead_warn(
         &self,
         offset: usize,
-    ) -> Result<&'r ExtractedToken<'t>, ParseError> {
+    ) -> Result<&'r ExtractedToken<'t>, ParseWarning> {
         self.look_ahead(offset)
-            .ok_or_else(|| self.make_error(ParseErrorKind::EndOfInput))
+            .ok_or_else(|| self.make_warn(ParseWarningKind::EndOfInput))
     }
 
     // Utilities
     #[cold]
     #[inline]
-    pub fn make_error(&self, kind: ParseErrorKind) -> ParseError {
-        ParseError::new(kind, self.rule, self.current)
+    pub fn make_warn(&self, kind: ParseWarningKind) -> ParseWarning {
+        ParseWarning::new(kind, self.rule, self.current)
     }
 }

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -18,10 +18,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::parse::error::{ParseError, ParseException};
+use crate::parse::exception::{ParseException, ParseWarning};
 use std::marker::PhantomData;
 
-pub type ParseResult<'r, 't, T> = Result<ParseSuccess<'r, 't, T>, ParseError>;
+pub type ParseResult<'r, 't, T> = Result<ParseSuccess<'r, 't, T>, ParseWarning>;
 pub type ParseSuccessTuple<'t, T> = (T, Vec<ParseException<'t>>);
 
 #[must_use]

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -24,7 +24,7 @@ mod prelude {
     pub use crate::parse::condition::ParseCondition;
     pub use crate::parse::parser::Parser;
     pub use crate::parse::prelude::*;
-    pub use crate::parse::{ParseError, Token};
+    pub use crate::parse::{ParseWarning, Token};
     pub use crate::tree::Element;
 }
 

--- a/src/parse/rule/impls/block/mod.rs
+++ b/src/parse/rule/impls/block/mod.rs
@@ -71,7 +71,7 @@ pub struct BlockRule {
 impl BlockRule {
     /// Produces a pseudo parse `Rule` associated with this `BlockRule`.
     ///
-    /// It should not be invoked, it is for error construction.
+    /// It should not be invoked, it is for warning construction.
     #[cold]
     pub fn rule(&self) -> Rule {
         // Stubbed try_consume_fn implementation for the Rule.

--- a/src/parse/rule/impls/block/rule.rs
+++ b/src/parse/rule/impls/block/rule.rs
@@ -99,7 +99,7 @@ fn block_skip<'r, 't>(
     if result {
         ok!(Element::Null)
     } else {
-        Err(parser.make_error(ParseErrorKind::RuleFailed))
+        Err(parser.make_warn(ParseWarningKind::RuleFailed))
     }
 }
 
@@ -134,12 +134,12 @@ where
     // Get the block rule for this name
     let block = match get_block_rule_with_name(name) {
         Some(block) => block,
-        None => return Err(parser.make_error(ParseErrorKind::NoSuchBlock)),
+        None => return Err(parser.make_warn(ParseWarningKind::NoSuchBlock)),
     };
 
     // Check if this block allows special invocation (the '[[*' token)
     if !block.accepts_special && special {
-        return Err(parser.make_error(ParseErrorKind::InvalidSpecialBlock));
+        return Err(parser.make_warn(ParseWarningKind::InvalidSpecialBlock));
     }
 
     // Prepare to run the block's parsing function

--- a/src/parse/rule/impls/comment.rs
+++ b/src/parse/rule/impls/comment.rs
@@ -57,7 +57,7 @@ fn try_consume_fn<'p, 'r, 't>(
             Token::InputEnd => {
                 trace!(log, "Reached end of input, aborting");
 
-                return Err(parser.make_error(ParseErrorKind::EndOfInput));
+                return Err(parser.make_warn(ParseWarningKind::EndOfInput));
             }
 
             // Consume any other token

--- a/src/parse/rule/impls/link_single.rs
+++ b/src/parse/rule/impls/link_single.rs
@@ -83,7 +83,7 @@ fn try_consume_link<'p, 'r, 't>(
     )?;
 
     if !url_valid(url) {
-        return Err(parser.make_error(ParseErrorKind::InvalidUrl));
+        return Err(parser.make_warn(ParseWarningKind::InvalidUrl));
     }
 
     debug!(

--- a/src/parse/rule/impls/link_triple.rs
+++ b/src/parse/rule/impls/link_triple.rs
@@ -99,7 +99,7 @@ fn try_consume_link<'p, 'r, 't>(
 
     // If url is an empty string, parsing should fail, there's nothing here
     if url.is_empty() {
-        return Err(parser.make_error(ParseErrorKind::RuleFailed));
+        return Err(parser.make_warn(ParseWarningKind::RuleFailed));
     }
 
     // Determine what token we ended on, i.e. which [[[ variant it is.

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -23,7 +23,7 @@ mod prelude {
     pub use crate::parse::collect::*;
     pub use crate::parse::condition::ParseCondition;
     pub use crate::parse::consume::consume;
-    pub use crate::parse::error::{ParseError, ParseErrorKind, ParseException};
+    pub use crate::parse::exception::{ParseException, ParseWarning, ParseWarningKind};
     pub use crate::parse::parser::Parser;
     pub use crate::parse::result::{ParseResult, ParseSuccess};
     pub use crate::parse::rule::Rule;

--- a/src/parse/rule/impls/raw.rs
+++ b/src/parse/rule/impls/raw.rs
@@ -54,8 +54,8 @@ fn try_consume_fn<'p, 'r, 't>(
         trace!(log, "First token is '@@', checking for special cases");
 
         // Get next two tokens. If they don't exist, exit early
-        let next_1 = parser.look_ahead_error(0)?;
-        let next_2 = parser.look_ahead_error(1)?;
+        let next_1 = parser.look_ahead_warn(0)?;
+        let next_2 = parser.look_ahead_warn(1)?;
 
         // Determine which case they fall under
         match (next_1.token, next_2.token) {
@@ -92,7 +92,7 @@ fn try_consume_fn<'p, 'r, 't>(
             // "@@ \n @@" -> Abort
             (Token::LineBreak, Token::Raw) | (Token::ParagraphBreak, Token::Raw) => {
                 debug!(log, "Found interrupted raw, aborting");
-                return Err(parser.make_error(ParseErrorKind::RuleFailed));
+                return Err(parser.make_warn(ParseWarningKind::RuleFailed));
             }
 
             // "@@ [something] @@" -> Element::Raw(token)
@@ -153,14 +153,14 @@ fn try_consume_fn<'p, 'r, 't>(
             Token::LineBreak | Token::ParagraphBreak => {
                 trace!(log, "Reached newline, aborting");
 
-                return Err(parser.make_error(ParseErrorKind::RuleFailed));
+                return Err(parser.make_warn(ParseWarningKind::RuleFailed));
             }
 
             // Hit the end of the input, abort
             Token::InputEnd => {
                 trace!(log, "Reached end of input, aborting");
 
-                return Err(parser.make_error(ParseErrorKind::EndOfInput));
+                return Err(parser.make_warn(ParseWarningKind::EndOfInput));
             }
 
             // No special handling, append to slices like normal

--- a/src/parse/rule/impls/todo.rs
+++ b/src/parse/rule/impls/todo.rs
@@ -32,7 +32,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &slog::Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Element<'t>> {
-    error!(log, "Encountered unimplemented rule! Returning error");
+    error!(log, "Encountered unimplemented rule! Returning warning");
 
-    Err(parser.make_error(ParseErrorKind::NotImplemented))
+    Err(parser.make_warn(ParseWarningKind::NotImplemented))
 }

--- a/src/parse/rule/mapping.rs
+++ b/src/parse/rule/mapping.rs
@@ -30,7 +30,7 @@ lazy_static! {
     ///
     /// An empty list means that this is a special token that shouldn't be used
     /// in this manner. It will of course fall back to interpreting this token
-    /// as text, but will also produce an error for the user.
+    /// as text, but will also produce a warning for the user.
     pub static ref RULE_MAP: EnumMap<Token, Vec<Rule>> = {
         enum_map! {
             // Symbols

--- a/src/render/debug.rs
+++ b/src/render/debug.rs
@@ -67,10 +67,10 @@ fn debug() {
         text!(" "),
         Element::Container(Container::new(ContainerType::Bold, vec![text!("banana")])),
     ];
-    let errors = vec![];
+    let warnings = vec![];
     let styles = vec![cow!("span.hidden-text { display: none; }")];
 
-    let result = SyntaxTree::from_element_result(elements, errors, styles);
+    let result = SyntaxTree::from_element_result(elements, warnings, styles);
     let (tree, _) = result.into();
 
     // Perform rendering

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -96,10 +96,10 @@ fn json() {
         text!(" "),
         Element::Container(Container::new(ContainerType::Bold, vec![text!("banana")])),
     ];
-    let errors = vec![];
+    let warnings = vec![];
     let styles = vec![cow!("span.hidden-text { display: none; }")];
 
-    let result = SyntaxTree::from_element_result(elements, errors, styles);
+    let result = SyntaxTree::from_element_result(elements, warnings, styles);
     let (tree, _) = result.into();
 
     // Perform renderings

--- a/src/test.rs
+++ b/src/test.rs
@@ -20,7 +20,7 @@
 
 //! Retrieves tests from JSON in the root `/test` directory, and runs them.
 
-use crate::parse::ParseError;
+use crate::parse::ParseWarning;
 use crate::tree::SyntaxTree;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
@@ -47,7 +47,7 @@ struct Test<'a> {
     name: String,
     input: String,
     tree: SyntaxTree<'a>,
-    errors: Vec<ParseError>,
+    warnings: Vec<ParseWarning>,
 }
 
 impl Test<'_> {
@@ -87,7 +87,7 @@ impl Test<'_> {
 
         let tokens = crate::tokenize(log, &self.input);
         let result = crate::parse(log, &tokens);
-        let (tree, errors) = result.into();
+        let (tree, warnings) = result.into();
 
         fn json<T>(object: &T) -> String
         where
@@ -107,17 +107,17 @@ impl Test<'_> {
                 self.tree,
                 tree,
                 json(&tree),
-                &errors,
+                &warnings,
             );
         }
 
-        if errors != self.errors {
+        if warnings != self.warnings {
             panic!(
                 "Running test '{}' failed! Errors did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nTree (correct): {:#?}",
                 self.name,
-                self.errors,
-                errors,
-                json(&errors),
+                self.warnings,
+                warnings,
+                json(&warnings),
                 &tree,
             );
         }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -24,7 +24,7 @@ mod element;
 pub use self::container::*;
 pub use self::element::*;
 
-use crate::parse::{ParseError, ParseOutcome};
+use crate::parse::{ParseOutcome, ParseWarning};
 use std::borrow::Cow;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
@@ -48,10 +48,10 @@ pub struct SyntaxTree<'t> {
 impl<'t> SyntaxTree<'t> {
     pub(crate) fn from_element_result(
         elements: Vec<Element<'t>>,
-        errors: Vec<ParseError>,
+        warnings: Vec<ParseWarning>,
         styles: Vec<Cow<'t, str>>,
     ) -> ParseOutcome<Self> {
         let tree = SyntaxTree { elements, styles };
-        ParseOutcome::new(tree, errors)
+        ParseOutcome::new(tree, warnings)
     }
 }

--- a/test/bold-empty.json
+++ b/test/bold-empty.json
@@ -30,6 +30,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/bold-fail-paragraph.json
+++ b/test/bold-fail-paragraph.json
@@ -38,7 +38,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "paragraph-break",
             "rule": "bold",

--- a/test/bold-fail.json
+++ b/test/bold-fail.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "bold",

--- a/test/bold-italics-underline.json
+++ b/test/bold-italics-underline.json
@@ -74,6 +74,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/bold-italics.json
+++ b/test/bold-italics.json
@@ -50,6 +50,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/bold-nested.json
+++ b/test/bold-nested.json
@@ -130,6 +130,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/bold.json
+++ b/test/bold.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/code-block.json
+++ b/test/code-block.json
@@ -21,6 +21,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/code-empty.json
+++ b/test/code-empty.json
@@ -21,6 +21,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/code-fail-arguments.json
+++ b/test/code-fail-arguments.json
@@ -46,7 +46,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "identifier",
             "rule": "block-code",

--- a/test/code-fail-head.json
+++ b/test/code-fail-head.json
@@ -42,7 +42,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "block-code",

--- a/test/code-fail-tail.json
+++ b/test/code-fail-tail.json
@@ -74,7 +74,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "left-block-end",
             "rule": "fallback",

--- a/test/code-fail.json
+++ b/test/code-fail.json
@@ -49,7 +49,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "block-code",

--- a/test/code-language-empty.json
+++ b/test/code-language-empty.json
@@ -21,6 +21,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/code-language-spaces.json
+++ b/test/code-language-spaces.json
@@ -21,6 +21,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/code-language.json
+++ b/test/code-language.json
@@ -21,6 +21,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/code-multiline.json
+++ b/test/code-multiline.json
@@ -21,6 +21,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/code-spaces.json
+++ b/test/code-spaces.json
@@ -21,6 +21,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/code-uppercase.json
+++ b/test/code-uppercase.json
@@ -21,6 +21,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/code.json
+++ b/test/code.json
@@ -21,6 +21,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/color-fail.json
+++ b/test/color-fail.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "color",

--- a/test/color-hex.json
+++ b/test/color-hex.json
@@ -38,6 +38,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/color-simple.json
+++ b/test/color-simple.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/comment-fail-left.json
+++ b/test/comment-fail-left.json
@@ -34,7 +34,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "comment",

--- a/test/comment-fail-right.json
+++ b/test/comment-fail-right.json
@@ -34,7 +34,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "right-comment",
             "rule": "fallback",

--- a/test/comment-multiline.json
+++ b/test/comment-multiline.json
@@ -30,6 +30,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/comment-single.json
+++ b/test/comment-single.json
@@ -30,6 +30,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/css-fail.json
+++ b/test/css-fail.json
@@ -41,7 +41,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "block-css",

--- a/test/css-multiline.json
+++ b/test/css-multiline.json
@@ -7,6 +7,6 @@
             "h1 {\n    margin-top: .7em\n    padding: 0;\n    font-weight: bold;\n}"
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/css-multiple.json
+++ b/test/css-multiple.json
@@ -30,6 +30,6 @@
             "b { display: none; }"
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/css.json
+++ b/test/css.json
@@ -7,6 +7,6 @@
             "a { color: blue; }"
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-class.json
+++ b/test/div-class.json
@@ -36,6 +36,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-empty-2.json
+++ b/test/div-empty-2.json
@@ -35,6 +35,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-empty.json
+++ b/test/div-empty.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-ending.json
+++ b/test/div-ending.json
@@ -36,6 +36,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-id.json
+++ b/test/div-id.json
@@ -36,6 +36,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-multiline.json
+++ b/test/div-multiline.json
@@ -43,6 +43,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-nested-deep.json
+++ b/test/div-nested-deep.json
@@ -102,6 +102,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-nested.json
+++ b/test/div-nested.json
@@ -74,6 +74,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-paragraphs.json
+++ b/test/div-paragraphs.json
@@ -67,6 +67,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div-style.json
+++ b/test/div-style.json
@@ -36,6 +36,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div.json
+++ b/test/div.json
@@ -28,6 +28,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2-class.json
+++ b/test/div2-class.json
@@ -28,6 +28,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2-empty-2.json
+++ b/test/div2-empty-2.json
@@ -35,6 +35,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2-empty.json
+++ b/test/div2-empty.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2-ending.json
+++ b/test/div2-ending.json
@@ -28,6 +28,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2-id.json
+++ b/test/div2-id.json
@@ -28,6 +28,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2-multiline.json
+++ b/test/div2-multiline.json
@@ -35,6 +35,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2-nested-deep.json
+++ b/test/div2-nested-deep.json
@@ -70,6 +70,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2-nested.json
+++ b/test/div2-nested.json
@@ -58,6 +58,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2-style.json
+++ b/test/div2-style.json
@@ -28,6 +28,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/div2.json
+++ b/test/div2.json
@@ -28,6 +28,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/em-dash.json
+++ b/test/em-dash.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/empty.json
+++ b/test/empty.json
@@ -6,6 +6,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/hr-2-fail.json
+++ b/test/hr-2-fail.json
@@ -33,6 +33,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/hr-3.json
+++ b/test/hr-3.json
@@ -32,6 +32,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/hr-4.json
+++ b/test/hr-4.json
@@ -32,6 +32,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/hr-5.json
+++ b/test/hr-5.json
@@ -32,6 +32,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/italics-empty.json
+++ b/test/italics-empty.json
@@ -30,6 +30,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/italics-fail-paragraph.json
+++ b/test/italics-fail-paragraph.json
@@ -38,7 +38,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "paragraph-break",
             "rule": "italics",

--- a/test/italics-fail.json
+++ b/test/italics-fail.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "italics",

--- a/test/italics.json
+++ b/test/italics.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-anchor-fail.json
+++ b/test/link-anchor-fail.json
@@ -26,7 +26,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "link-anchor",

--- a/test/link-anchor-fake.json
+++ b/test/link-anchor-fake.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-anchor.json
+++ b/test/link-anchor.json
@@ -28,6 +28,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-single-fail-brackets.json
+++ b/test/link-single-fail-brackets.json
@@ -50,6 +50,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-single-fail-new-tab.json
+++ b/test/link-single-fail-new-tab.json
@@ -50,7 +50,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "identifier",
             "rule": "link-single-new-tab",

--- a/test/link-single-fail-newline.json
+++ b/test/link-single-fail-newline.json
@@ -45,6 +45,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-single-fail-start.json
+++ b/test/link-single-fail-start.json
@@ -22,6 +22,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-single-fail-text.json
+++ b/test/link-single-fail-text.json
@@ -42,6 +42,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-single-fail-word.json
+++ b/test/link-single-fail-word.json
@@ -26,7 +26,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }
 

--- a/test/link-single-new-tab.json
+++ b/test/link-single-new-tab.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-single-url.json
+++ b/test/link-single-url.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-single.json
+++ b/test/link-single.json
@@ -28,6 +28,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple-fail-brackets-end.json
+++ b/test/link-triple-fail-brackets-end.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "right-link",
             "rule": "fallback",

--- a/test/link-triple-fail-brackets-left.json
+++ b/test/link-triple-fail-brackets-left.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "link-triple",

--- a/test/link-triple-fail-brackets-right.json
+++ b/test/link-triple-fail-brackets-right.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "right-link",
             "rule": "fallback",

--- a/test/link-triple-fail-newline.json
+++ b/test/link-triple-fail-newline.json
@@ -53,7 +53,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "line-break",
             "rule": "link-triple",

--- a/test/link-triple-fail-title-new-tab.json
+++ b/test/link-triple-fail-title-new-tab.json
@@ -38,7 +38,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "identifier",
             "rule": "link-triple-new-tab",

--- a/test/link-triple-fail-title.json
+++ b/test/link-triple-fail-title.json
@@ -38,7 +38,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "identifier",
             "rule": "link-triple",

--- a/test/link-triple-label-new-tab.json
+++ b/test/link-triple-label-new-tab.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple-label.json
+++ b/test/link-triple-label.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple-new-tab.json
+++ b/test/link-triple-new-tab.json
@@ -22,6 +22,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple-title-new-tab.json
+++ b/test/link-triple-title-new-tab.json
@@ -22,6 +22,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple-title.json
+++ b/test/link-triple-title.json
@@ -22,6 +22,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple-url-whitespace.json
+++ b/test/link-triple-url-whitespace.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple-url.json
+++ b/test/link-triple-url.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple-whitespace-new-tab.json
+++ b/test/link-triple-whitespace-new-tab.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple-whitespace.json
+++ b/test/link-triple-whitespace.json
@@ -24,6 +24,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-triple.json
+++ b/test/link-triple.json
@@ -22,6 +22,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/link-url.json
+++ b/test/link-url.json
@@ -30,6 +30,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/monospace-fail-left.json
+++ b/test/monospace-fail-left.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "monospace",

--- a/test/monospace-fail-paragraph.json
+++ b/test/monospace-fail-paragraph.json
@@ -38,7 +38,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "paragraph-break",
             "rule": "monospace",

--- a/test/monospace-fail-right.json
+++ b/test/monospace-fail-right.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "right-monospace",
             "rule": "fallback",

--- a/test/monospace.json
+++ b/test/monospace.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/paragraphs.json
+++ b/test/paragraphs.json
@@ -46,6 +46,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-0.json
+++ b/test/raw-0.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-1.json
+++ b/test/raw-1.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-2.json
+++ b/test/raw-2.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-angles-content.json
+++ b/test/raw-angles-content.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-angles-empty.json
+++ b/test/raw-angles-empty.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-fail-newline-angles.json
+++ b/test/raw-fail-newline-angles.json
@@ -33,7 +33,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "line-break",
             "rule": "raw",

--- a/test/raw-fail-newline.json
+++ b/test/raw-fail-newline.json
@@ -33,7 +33,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "raw",
             "rule": "raw",

--- a/test/raw-fail-paragraph.json
+++ b/test/raw-fail-paragraph.json
@@ -38,7 +38,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "paragraph-break",
             "rule": "raw",

--- a/test/raw-other-angles.json
+++ b/test/raw-other-angles.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-test-0.json
+++ b/test/raw-test-0.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-test-1.json
+++ b/test/raw-test-1.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-test-2.json
+++ b/test/raw-test-2.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/raw-token.json
+++ b/test/raw-token.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/simple-newline.json
+++ b/test/simple-newline.json
@@ -17,6 +17,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/simple-space.json
+++ b/test/simple-space.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/simple-symbol.json
+++ b/test/simple-symbol.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/simple-text.json
+++ b/test/simple-text.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/spaces.json
+++ b/test/spaces.json
@@ -18,6 +18,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/strikethrough-empty.json
+++ b/test/strikethrough-empty.json
@@ -25,6 +25,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/strikethrough-fail-paragraph.json
+++ b/test/strikethrough-fail-paragraph.json
@@ -38,6 +38,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/strikethrough-fail.json
+++ b/test/strikethrough-fail.json
@@ -30,6 +30,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/strikethrough.json
+++ b/test/strikethrough.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/subscript-empty.json
+++ b/test/subscript-empty.json
@@ -30,6 +30,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/subscript-fail.json
+++ b/test/subscript-fail.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "subscript",

--- a/test/subscript.json
+++ b/test/subscript.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/superscript-empty.json
+++ b/test/superscript-empty.json
@@ -30,6 +30,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/superscript-fail.json
+++ b/test/superscript-fail.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "superscript",

--- a/test/superscript.json
+++ b/test/superscript.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/symbols.json
+++ b/test/symbols.json
@@ -98,6 +98,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/underline-empty.json
+++ b/test/underline-empty.json
@@ -30,6 +30,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }

--- a/test/underline-fail-paragraph.json
+++ b/test/underline-fail-paragraph.json
@@ -38,7 +38,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "paragraph-break",
             "rule": "underline",

--- a/test/underline-fail.json
+++ b/test/underline-fail.json
@@ -30,7 +30,7 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
         {
             "token": "input-end",
             "rule": "underline",

--- a/test/underline.json
+++ b/test/underline.json
@@ -34,6 +34,6 @@
         "styles": [
         ]
     },
-    "errors": [
+    "warnings": [
     ]
 }


### PR DESCRIPTION
As all errors are explicitly non-fatal, as described in the project philosophy, it is better to name these as "warnings" instead.

While they are errors in parsing, they are not used as such in the code.