### PR TITLE
Add lines block

### DIFF
--- a/src/parse/rule/impls/block/blocks/lines.rs
+++ b/src/parse/rule/impls/block/blocks/lines.rs
@@ -49,7 +49,6 @@ fn parse_fn<'r, 't>(
 
     let argument =
         parser.get_argument_value(Some(ParseWarningKind::BlockMalformedArguments))?;
-    parser.get_end_block()?;
 
     let count = match argument.trim().parse() {
         Ok(count) => count,

--- a/src/parse/rule/impls/block/blocks/lines.rs
+++ b/src/parse/rule/impls/block/blocks/lines.rs
@@ -1,0 +1,64 @@
+/*
+ * parse/rule/impls/block/blocks/lines.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+
+pub const BLOCK_LINES: BlockRule = BlockRule {
+    name: "block-lines",
+    accepts_names: &["lines"],
+    accepts_special: false,
+    newline_separator: true,
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    special: bool,
+    in_block: bool,
+) -> ParseResult<'r, 't, Element<'t>> {
+    debug!(log, "Parsing newlines block"; "in-block" => in_block);
+
+    assert_eq!(special, false, "Code doesn't allow special variant");
+    assert!(
+        name.eq_ignore_ascii_case("lines"),
+        "Code doesn't have a valid name",
+    );
+
+    if !in_block {
+        return Err(parser.make_warn(ParseWarningKind::BlockMalformedArguments));
+    }
+
+    let argument =
+        parser.get_argument_value(Some(ParseWarningKind::BlockMalformedArguments))?;
+    parser.get_end_block()?;
+
+    let count = match argument.trim().parse() {
+        Ok(count) => count,
+        Err(error) => {
+            debug!(log, "Invalid numeric expression: {}", error);
+
+            return Err(parser.make_warn(ParseWarningKind::BlockMalformedArguments));
+        }
+    };
+
+    ok!(Element::LineBreaks { count })
+}

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -32,7 +32,9 @@ mod prelude {
 mod code;
 mod css;
 mod div;
+mod lines;
 
 pub use self::code::BLOCK_CODE;
 pub use self::css::BLOCK_CSS;
 pub use self::div::BLOCK_DIV;
+pub use self::lines::BLOCK_LINES;

--- a/src/parse/rule/impls/block/mapping.rs
+++ b/src/parse/rule/impls/block/mapping.rs
@@ -22,7 +22,7 @@ use super::{blocks::*, BlockRule};
 use std::collections::HashMap;
 use unicase::UniCase;
 
-pub const BLOCK_RULES: [BlockRule; 3] = [BLOCK_CODE, BLOCK_CSS, BLOCK_DIV];
+pub const BLOCK_RULES: [BlockRule; 4] = [BLOCK_CODE, BLOCK_CSS, BLOCK_DIV, BLOCK_LINES];
 
 pub type BlockRuleMap = HashMap<UniCase<&'static str>, &'static BlockRule>;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -102,7 +102,7 @@ impl Test<'_> {
 
         if tree != self.tree {
             panic!(
-                "Running test '{}' failed! AST did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nErrors: {:#?}",
+                "Running test '{}' failed! AST did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nWarnings: {:#?}",
                 self.name,
                 self.tree,
                 tree,
@@ -113,7 +113,7 @@ impl Test<'_> {
 
         if warnings != self.warnings {
             panic!(
-                "Running test '{}' failed! Errors did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nTree (correct): {:#?}",
+                "Running test '{}' failed! Warnings did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nTree (correct): {:#?}",
                 self.name,
                 self.warnings,
                 warnings,

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -87,6 +87,9 @@ pub enum Element<'t> {
     /// This calls for a newline in the final output, such as `<br>` in HTML.
     LineBreak,
 
+    /// A collection of line breaks adjacent to each other.
+    LineBreaks { count: u32 },
+
     /// A horizontal rule.
     HorizontalRule,
 
@@ -109,6 +112,7 @@ impl Element<'_> {
             Element::Div { .. } => "Div",
             Element::Code { .. } => "Code",
             Element::LineBreak => "LineBreak",
+            Element::LineBreaks { .. } => "LineBreaks",
             Element::HorizontalRule => "HorizontalRule",
             Element::Null => "Null",
         }

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -21,6 +21,7 @@
 use super::Container;
 use crate::enums::{AnchorTarget, LinkLabel};
 use std::borrow::Cow;
+use std::num::NonZeroU32;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", tag = "element", content = "data")]
@@ -88,7 +89,7 @@ pub enum Element<'t> {
     LineBreak,
 
     /// A collection of line breaks adjacent to each other.
-    LineBreaks { count: u32 },
+    LineBreaks { count: NonZeroU32 },
 
     /// A horizontal rule.
     HorizontalRule,

--- a/test/line-breaks-error-0.json
+++ b/test/line-breaks-error-0.json
@@ -1,0 +1,57 @@
+{
+    "input": "[[lines 0]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "[["
+                        },
+                        {
+                            "element": "text",
+                            "data": "lines"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "0"
+                        },
+                        {
+                            "element": "text",
+                            "data": "]]"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+        {
+            "token": "input-end",
+            "rule": "block-lines",
+            "span": [11, 11],
+            "kind": "block-malformed-arguments"
+        },
+        {
+            "token": "left-block",
+            "rule": "fallback",
+            "span": [0, 2],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "right-block",
+            "rule": "fallback",
+            "span": [9, 11],
+            "kind": "no-rules-match"
+        }
+    ]
+}

--- a/test/line-breaks-error-invalid.json
+++ b/test/line-breaks-error-invalid.json
@@ -1,0 +1,57 @@
+{
+    "input": "[[lines apple]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "[["
+                        },
+                        {
+                            "element": "text",
+                            "data": "lines"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "apple"
+                        },
+                        {
+                            "element": "text",
+                            "data": "]]"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+        {
+            "token": "input-end",
+            "rule": "block-lines",
+            "span": [15, 15],
+            "kind": "block-malformed-arguments"
+        },
+        {
+            "token": "left-block",
+            "rule": "fallback",
+            "span": [0, 2],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "right-block",
+            "rule": "fallback",
+            "span": [13, 15],
+            "kind": "no-rules-match"
+        }
+    ]
+}

--- a/test/line-breaks-error-negative.json
+++ b/test/line-breaks-error-negative.json
@@ -1,0 +1,61 @@
+{
+    "input": "[[lines -5]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "[["
+                        },
+                        {
+                            "element": "text",
+                            "data": "lines"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "-"
+                        },
+                        {
+                            "element": "text",
+                            "data": "5"
+                        },
+                        {
+                            "element": "text",
+                            "data": "]]"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+        {
+            "token": "input-end",
+            "rule": "block-lines",
+            "span": [12, 12],
+            "kind": "block-malformed-arguments"
+        },
+        {
+            "token": "left-block",
+            "rule": "fallback",
+            "span": [0, 2],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "right-block",
+            "rule": "fallback",
+            "span": [10, 12],
+            "kind": "no-rules-match"
+        }
+    ]
+}

--- a/test/line-breaks-uppercase.json
+++ b/test/line-breaks-uppercase.json
@@ -1,0 +1,36 @@
+{
+    "input": "Apple\n[[  LiNEs 12  ]]\nBanana",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        },
+                        {
+                            "element": "line-breaks",
+                            "data": {
+                                "count": 12
+                            }
+                        },
+                        {
+                            "element": "line-break"
+                        },
+                        {
+                            "element": "text",
+                            "data": "Banana"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/line-breaks.json
+++ b/test/line-breaks.json
@@ -1,0 +1,36 @@
+{
+    "input": "Apple\n[[lines 3]]\nBanana",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        },
+                        {
+                            "element": "line-breaks",
+                            "data": {
+                                "count": 3
+                            }
+                        },
+                        {
+                            "element": "line-break"
+                        },
+                        {
+                            "element": "text",
+                            "data": "Banana"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}


### PR DESCRIPTION
Adds `[[lines X]]` to permit having multiple line breaks added without weird syntactical constructs like spamming `@@@@`s

