### PR TITLE
Add max depth for the parser

### DIFF
--- a/src/parse/consume.rs
+++ b/src/parse/consume.rs
@@ -47,8 +47,11 @@ pub fn consume<'p, 'r, 't>(
         "remaining-len" => parser.remaining().len(),
     ));
 
-    debug!(log, "Looking for valid rules");
+    // Incrementing recursion depth
+    // Will fail if we're too many layers in
+    parser.depth_increment()?;
 
+    debug!(log, "Looking for valid rules");
     let mut all_exceptions = Vec::new();
     let current = parser.current();
 
@@ -72,6 +75,9 @@ pub fn consume<'p, 'r, 't>(
                 // unsuccessful attempts.
                 mem::drop(all_exceptions);
 
+                // Decrement recursion depth
+                parser.depth_decrement();
+
                 return Ok(output);
             }
             Err(warning) => {
@@ -94,6 +100,9 @@ pub fn consume<'p, 'r, 't>(
         RULE_FALLBACK,
         current,
     )));
+
+    // Decrement recursion depth
+    parser.depth_decrement();
 
     ok!(element, all_exceptions)
 }

--- a/src/parse/exception.rs
+++ b/src/parse/exception.rs
@@ -95,7 +95,6 @@ impl ParseWarning {
 #[serde(rename_all = "kebab-case")]
 pub enum ParseWarningKind {
     /// The self-enforced recursion limit has been passed, giving up.
-    #[allow(dead_code)]
     RecursionDepthExceeded,
 
     /// Attempting to process this rule failed because the end of input was reached.

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -107,8 +107,7 @@ where
 
             warn!(
                 log,
-                "Fatal error occurred at highest-level parsing: {:#?}",
-                warning,
+                "Fatal error occurred at highest-level parsing: {:#?}", warning,
             );
 
             let elements = vec![text!(tokenization.full_text().inner())];

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -100,16 +100,22 @@ where
             SyntaxTree::from_element_result(elements, warnings, styles)
         }
         Err(warning) => {
-            // This path is only reachable if invalid_tokens is non-empty.
-            // As this is the highest-level, we do not have any premature ending tokens,
-            // but rather keep going until the end of the input.
+            // This path is only reachable if a very bad error occurs.
             //
-            // Thus this path should not be reached.
+            // If this happens, then just return the input source as the output
+            // and the warning.
 
-            panic!(
-                "Got parse warning from highest-level paragraph gather: {:#?}",
+            warn!(
+                log,
+                "Fatal error occurred at highest-level parsing: {:#?}",
                 warning,
             );
+
+            let elements = vec![text!(tokenization.full_text().inner())];
+            let warnings = vec![warning];
+            let styles = vec![];
+
+            SyntaxTree::from_element_result(elements, warnings, styles)
         }
     }
 }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -26,7 +26,7 @@ use crate::span_wrap::SpanWrap;
 use crate::tokenize::Tokenization;
 use std::ptr;
 
-const MAX_RECURSION_DEPTH: usize = 250;
+const MAX_RECURSION_DEPTH: usize = 100;
 
 #[derive(Debug, Clone)]
 pub struct Parser<'r, 't> {

--- a/src/text.rs
+++ b/src/text.rs
@@ -36,6 +36,17 @@ impl<'t> FullText<'t> {
         FullText { text }
     }
 
+    /// Returns the entire inner string. This should not be used.
+    ///
+    /// If you wish to slice between tokens, use the other methods instead.
+    /// This is for very unusual cases where you need the entire input string
+    /// as-is, with no tokenization.
+    #[inline]
+    #[doc(hidden)]
+    pub(crate) fn inner(&self) -> &'t str {
+        self.text
+    }
+
     /// Slices from the given start to end token.
     ///
     /// This is performed inclusively, capturing both tokens on each side,


### PR DESCRIPTION
This will prevent denial-of-service attacks in the form of stack overflows, and a sane error for it, while keeping a high limit for regular use cases.

The recursion depth is set to 100.