### PR TITLE
Add collapsibles

### DIFF
--- a/src/parse/boolean.rs
+++ b/src/parse/boolean.rs
@@ -32,7 +32,6 @@ pub fn parse_boolean<S: AsRef<str>>(s: S) -> Result<bool, ()> {
     ];
 
     let s = s.as_ref().trim();
-
     for &(name, value) in &NAMES {
         if name.eq_ignore_ascii_case(s) {
             return Ok(value);

--- a/src/parse/boolean.rs
+++ b/src/parse/boolean.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/block/blocks/collapsible.rs
+ * parse/boolean.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Ammon Smith
@@ -18,23 +18,26 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::prelude::*;
-use crate::parse::parse_boolean;
+/// Parse a boolean string into its corresponding value.
+pub fn parse_boolean<S: AsRef<str>>(s: S) -> Result<bool, ()> {
+    const NAMES: [(&str, bool); 8] = [
+        ("true", true),
+        ("false", false),
+        ("t", true),
+        ("f", false),
+        ("1", true),
+        ("0", false),
+        ("yes", true),
+        ("no", false),
+    ];
 
-pub const BLOCK_COLLAPSIBLE: BlockRule = BlockRule {
-    name: "block-collapsible",
-    accepts_names: &["collapsible"],
-    accepts_special: false,
-    newline_separator: true,
-    parse_fn,
-};
+    let s = s.as_ref().trim();
 
-fn parse_fn<'r, 't>(
-    log: &slog::Logger,
-    parser: &mut Parser<'r, 't>,
-    name: &'t str,
-    special: bool,
-    in_block: bool,
-) -> ParseResult<'r, 't, Element<'t>> {
-    todo!()
+    for &(name, value) in &NAMES {
+        if name.eq_ignore_ascii_case(s) {
+            return Ok(value);
+        }
+    }
+
+    Err(())
 }

--- a/src/parse/exception.rs
+++ b/src/parse/exception.rs
@@ -121,8 +121,11 @@ pub enum ParseWarningKind {
     /// This block does not have close brackets when required.
     BlockMissingCloseBrackets,
 
-    /// Encountered malformed arguments when parsing block.
+    /// Encountered malformed arguments when parsing the block.
     BlockMalformedArguments,
+
+    /// Some required arguments where missing when parsing the block.
+    BlockMissingArguments,
 
     /// This block expects a line break here.
     BlockExpectedLineBreak,

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -21,6 +21,7 @@
 #[macro_use]
 mod macros;
 
+mod boolean;
 mod check_step;
 mod collect;
 mod condition;
@@ -50,6 +51,7 @@ use crate::tokenize::Tokenization;
 use crate::tree::SyntaxTree;
 use std::borrow::Cow;
 
+pub use self::boolean::parse_boolean;
 pub use self::exception::{ParseException, ParseWarning, ParseWarningKind};
 pub use self::outcome::ParseOutcome;
 pub use self::result::{ParseResult, ParseSuccess};

--- a/src/parse/paragraph/mod.rs
+++ b/src/parse/paragraph/mod.rs
@@ -122,14 +122,26 @@ where
 
         debug!(log, "Tokens consumed to produce element");
 
-        if element != Element::Null {
-            // Add the new element to the list
-            stack.push_element(element);
-        }
+        // Add the new element to the list
+        push_element(&mut stack, element);
 
         // Process exceptions
         stack.push_exceptions(&mut exceptions);
     }
 
     stack.into_result()
+}
+
+fn push_element<'t>(stack: &mut ParagraphStack<'t>, element: Element<'t>) {
+    // Don't add null elements
+    if element == Element::Null {
+        return;
+    }
+
+    // Don't add line break if the element is otherwise empty
+    if stack.current_empty() && element == Element::LineBreak {
+        return;
+    }
+
+    stack.push_element(element);
 }

--- a/src/parse/paragraph/stack.rs
+++ b/src/parse/paragraph/stack.rs
@@ -49,6 +49,11 @@ impl<'t> ParagraphStack<'t> {
     }
 
     #[inline]
+    pub fn current_empty(&self) -> bool {
+        self.current.is_empty()
+    }
+
+    #[inline]
     pub fn push_element(&mut self, element: Element<'t>) {
         debug!(
             self.log,

--- a/src/parse/rule/impls/block/blocks/code.rs
+++ b/src/parse/rule/impls/block/blocks/code.rs
@@ -43,11 +43,8 @@ fn parse_fn<'r, 't>(
         "Code doesn't have a valid name",
     );
 
-    let language = if in_block {
-        parser.get_argument_map()?.get("type")
-    } else {
-        None
-    };
+    let mut arguments = parser.get_head_map(&BLOCK_CODE, in_block)?;
+    let language = arguments.get("type");
 
     let code = parser.get_body_text(&BLOCK_CODE)?;
     let element = Element::Code {

--- a/src/parse/rule/impls/block/blocks/code.rs
+++ b/src/parse/rule/impls/block/blocks/code.rs
@@ -33,9 +33,9 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
-    in_block: bool,
+    in_head: bool,
 ) -> ParseResult<'r, 't, Element<'t>> {
-    debug!(log, "Parsing code block"; "in-block" => in_block);
+    debug!(log, "Parsing code block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Code doesn't allow special variant");
     assert!(
@@ -43,7 +43,7 @@ fn parse_fn<'r, 't>(
         "Code doesn't have a valid name",
     );
 
-    let mut arguments = parser.get_head_map(&BLOCK_CODE, in_block)?;
+    let mut arguments = parser.get_head_map(&BLOCK_CODE, in_head)?;
     let language = arguments.get("type");
 
     let code = parser.get_body_text(&BLOCK_CODE)?;

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -82,8 +82,12 @@ fn parse_fn<'r, 't>(
         None => (true, false),
     };
 
-    todo!();
+    // Get body content, with paragraphs
+    let (elements, exceptions) = parser
+        .get_body_elements(&BLOCK_COLLAPSIBLE, true)?
+        .into();
 
+    // Build element and return
     let element = Element::Collapsible {
         elements,
         start_open,

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -34,12 +34,12 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
-    in_block: bool,
+    in_head: bool,
 ) -> ParseResult<'r, 't, Element<'t>> {
     debug!(
         log,
         "Parsing collapsible block";
-        "in-block" => in_block,
+        "in-head" => in_head,
     );
 
     assert_eq!(special, false, "Collapsible doesn't allow special variant");
@@ -48,7 +48,7 @@ fn parse_fn<'r, 't>(
         "Collapsible doesn't have a valid name",
     );
 
-    let mut arguments = parser.get_head_map(&BLOCK_COLLAPSIBLE, in_block)?;
+    let mut arguments = parser.get_head_map(&BLOCK_COLLAPSIBLE, in_head)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -48,11 +48,7 @@ fn parse_fn<'r, 't>(
         "Collapsible doesn't have a valid name",
     );
 
-    let mut arguments = if in_block {
-        parser.get_argument_map()?
-    } else {
-        Arguments::new()
-    };
+    let mut arguments = parser.get_head_map(&BLOCK_COLLAPSIBLE, in_block)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -82,7 +82,21 @@ fn parse_fn<'r, 't>(
         None => (true, false),
     };
 
-    todo!()
+    todo!();
+
+    let element = Element::Collapsible {
+        elements,
+        start_open,
+        show_text,
+        hide_text,
+        show_top,
+        show_bottom,
+        id,
+        class,
+        style,
+    };
+
+    ok!(element, exceptions)
 }
 
 fn parse_hide_location(s: &str, parser: &Parser) -> Result<(bool, bool), ParseWarning> {

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -66,7 +66,7 @@ fn parse_fn<'r, 't>(
             //
             // Also invert the result, "folded=yes" means "start_open=no".
             match parse_boolean(value) {
-                Ok(value) => Some(!value),
+                Ok(value) => !value,
                 Err(_) => {
                     return Err(
                         parser.make_warn(ParseWarningKind::BlockMalformedArguments)
@@ -74,7 +74,7 @@ fn parse_fn<'r, 't>(
                 }
             }
         }
-        None => None,
+        None => false,
     };
 
     let (show_top, show_bottom) = match arguments.get("hideLocation") {

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -87,9 +87,8 @@ fn parse_fn<'r, 't>(
     };
 
     // Get body content, with paragraphs
-    let (elements, exceptions) = parser
-        .get_body_elements(&BLOCK_COLLAPSIBLE, true)?
-        .into();
+    let (elements, exceptions) =
+        parser.get_body_elements(&BLOCK_COLLAPSIBLE, true)?.into();
 
     // Build element and return
     let element = Element::Collapsible {

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use crate::parse::parse_boolean;
+use crate::parse::{parse_boolean, ParseWarning, ParseWarningKind};
 
 pub const BLOCK_COLLAPSIBLE: BlockRule = BlockRule {
     name: "block-collapsible",
@@ -36,5 +36,72 @@ fn parse_fn<'r, 't>(
     special: bool,
     in_block: bool,
 ) -> ParseResult<'r, 't, Element<'t>> {
+    debug!(
+        log,
+        "Parsing collapsible block";
+        "in-block" => in_block,
+    );
+
+    assert_eq!(special, false, "Collapsible doesn't allow special variant");
+
+    let mut arguments = if in_block {
+        parser.get_argument_map()?
+    } else {
+        Arguments::new()
+    };
+
+    // Get styling arguments
+    let id = arguments.get("id");
+    let class = arguments.get("class");
+    let style = arguments.get("style");
+
+    // Get display arguments
+    let show_text = arguments.get("show");
+    let hide_text = arguments.get("hide");
+
+    // Get folding arguments
+    let start_open = match arguments.get("folded") {
+        Some(value) => {
+            // Parse this argument as bool
+            //
+            // Also invert the result, "folded=yes" means "start_open=no".
+            match parse_boolean(value) {
+                Ok(value) => Some(!value),
+                Err(_) => {
+                    return Err(
+                        parser.make_warn(ParseWarningKind::BlockMalformedArguments)
+                    )
+                }
+            }
+        }
+        None => None,
+    };
+
+    let (show_top, show_bottom) = match arguments.get("hideLocation") {
+        Some(value) => parse_hide_location(&value, parser)?,
+        None => (true, false),
+    };
+
     todo!()
+}
+
+fn parse_hide_location(s: &str, parser: &Parser) -> Result<(bool, bool), ParseWarning> {
+    const NAMES: [(&str, (bool, bool)); 5] = [
+        ("top", (true, false)),
+        ("bottom", (false, true)),
+        ("both", (true, true)),
+        ("neither", (false, false)),
+        ("none", (false, false)),
+    ];
+
+    let s = s.trim();
+    for &(name, value) in &NAMES {
+        if name.eq_ignore_ascii_case(s) {
+            return Ok(value);
+        }
+    }
+
+    debug!(&parser.log(), "Unknown hideLocation argument"; "value" => s);
+
+    Err(parser.make_warn(ParseWarningKind::BlockMalformedArguments))
 }

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/block/blocks/mod.rs
+ * parse/rule/impls/block/blocks/collapsible.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Ammon Smith
@@ -18,24 +18,22 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use super::super::{Arguments, BlockRule};
-    pub use crate::parse::collect::*;
-    pub use crate::parse::condition::ParseCondition;
-    pub use crate::parse::parser::Parser;
-    pub use crate::parse::prelude::*;
-    pub use crate::parse::{ParseWarning, Token};
-    pub use crate::tree::Element;
+use super::prelude::*;
+
+pub const BLOCK_COLLAPSIBLE: BlockRule = BlockRule {
+    name: "block-collapsible",
+    accepts_names: &["collapsible"],
+    accepts_special: false,
+    newline_separator: true,
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    special: bool,
+    in_block: bool,
+) -> ParseResult<'r, 't, Element<'t>> {
+    todo!()
 }
-
-mod code;
-mod collapsible;
-mod css;
-mod div;
-mod lines;
-
-pub use self::code::BLOCK_CODE;
-pub use self::collapsible::BLOCK_COLLAPSIBLE;
-pub use self::css::BLOCK_CSS;
-pub use self::div::BLOCK_DIV;
-pub use self::lines::BLOCK_LINES;

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -43,6 +43,10 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Collapsible doesn't allow special variant");
+    assert!(
+        name.eq_ignore_ascii_case("collapsible"),
+        "Collapsible doesn't have a valid name",
+    );
 
     let mut arguments = if in_block {
         parser.get_argument_map()?

--- a/src/parse/rule/impls/block/blocks/css.rs
+++ b/src/parse/rule/impls/block/blocks/css.rs
@@ -43,9 +43,7 @@ fn parse_fn<'r, 't>(
         "Code doesn't have a valid name",
     );
 
-    if in_block {
-        parser.get_argument_none()?;
-    }
+    parser.get_head_none(&BLOCK_CSS, in_block)?;
 
     let css = parser.get_body_text(&BLOCK_CSS)?;
     let exceptions = vec![ParseException::Style(cow!(css))];

--- a/src/parse/rule/impls/block/blocks/css.rs
+++ b/src/parse/rule/impls/block/blocks/css.rs
@@ -33,9 +33,9 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
-    in_block: bool,
+    in_head: bool,
 ) -> ParseResult<'r, 't, Element<'t>> {
-    debug!(log, "Parsing CSS block"; "in-block" => in_block);
+    debug!(log, "Parsing CSS block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Code doesn't allow special variant");
     assert!(
@@ -43,7 +43,7 @@ fn parse_fn<'r, 't>(
         "Code doesn't have a valid name",
     );
 
-    parser.get_head_none(&BLOCK_CSS, in_block)?;
+    parser.get_head_none(&BLOCK_CSS, in_head)?;
 
     let css = parser.get_body_text(&BLOCK_CSS)?;
     let exceptions = vec![ParseException::Style(cow!(css))];

--- a/src/parse/rule/impls/block/blocks/div.rs
+++ b/src/parse/rule/impls/block/blocks/div.rs
@@ -33,18 +33,18 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
-    in_block: bool,
+    in_head: bool,
 ) -> ParseResult<'r, 't, Element<'t>> {
     debug!(
         log,
         "Parsing div block";
-        "in-block" => in_block,
+        "in-head" => in_head,
         "name" => name,
     );
 
     assert_eq!(special, false, "Div doesn't allow special variant");
 
-    let mut arguments = parser.get_head_map(&BLOCK_DIV, in_block)?;
+    let mut arguments = parser.get_head_map(&BLOCK_DIV, in_head)?;
 
     // "div" means we wrap in paragraphs, like normal
     // "div_" means we don't wrap it

--- a/src/parse/rule/impls/block/blocks/div.rs
+++ b/src/parse/rule/impls/block/blocks/div.rs
@@ -44,13 +44,7 @@ fn parse_fn<'r, 't>(
 
     assert_eq!(special, false, "Div doesn't allow special variant");
 
-    let mut arguments = if in_block {
-        parser.get_argument_map()?
-    } else {
-        Arguments::new()
-    };
-
-    parser.get_line_break()?;
+    let mut arguments = parser.get_head_map(&BLOCK_DIV, in_block)?;
 
     // "div" means we wrap in paragraphs, like normal
     // "div_" means we don't wrap it

--- a/src/parse/rule/impls/block/blocks/div.rs
+++ b/src/parse/rule/impls/block/blocks/div.rs
@@ -42,7 +42,7 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Code doesn't allow special variant");
+    assert_eq!(special, false, "Div doesn't allow special variant");
 
     let mut arguments = if in_block {
         parser.get_argument_map()?

--- a/src/parse/rule/impls/block/blocks/lines.rs
+++ b/src/parse/rule/impls/block/blocks/lines.rs
@@ -43,12 +43,10 @@ fn parse_fn<'r, 't>(
         "Code doesn't have a valid name",
     );
 
-    if !in_block {
-        return Err(parser.make_warn(ParseWarningKind::BlockMalformedArguments));
-    }
-
-    let argument =
-        parser.get_argument_value(Some(ParseWarningKind::BlockMalformedArguments))?;
+    let argument = parser.get_head_value(
+        &BLOCK_LINES, in_block,
+        Some(ParseWarningKind::BlockMalformedArguments),
+    )?;
 
     let count = match argument.trim().parse() {
         Ok(count) => count,

--- a/src/parse/rule/impls/block/mapping.rs
+++ b/src/parse/rule/impls/block/mapping.rs
@@ -22,7 +22,13 @@ use super::{blocks::*, BlockRule};
 use std::collections::HashMap;
 use unicase::UniCase;
 
-pub const BLOCK_RULES: [BlockRule; 4] = [BLOCK_CODE, BLOCK_CSS, BLOCK_DIV, BLOCK_LINES];
+pub const BLOCK_RULES: [BlockRule; 5] = [
+    BLOCK_CODE,
+    BLOCK_COLLAPSIBLE,
+    BLOCK_CSS,
+    BLOCK_DIV,
+    BLOCK_LINES,
+];
 
 pub type BlockRuleMap = HashMap<UniCase<&'static str>, &'static BlockRule>;
 

--- a/src/parse/rule/impls/block/mod.rs
+++ b/src/parse/rule/impls/block/mod.rs
@@ -108,7 +108,7 @@ impl Debug for BlockRule {
 /// * `parser` -- Parser instance
 /// * `name` -- The name of the block
 /// * `special` -- Whether this block is `[[*` (special) or `[[` (regular)
-/// * `in_block` -- Whether we're still in the block head, or if it's finished
+/// * `in_head` -- Whether we're still in the block head, or if it's finished
 pub type BlockParseFn = for<'r, 't> fn(
     &slog::Logger,
     &mut Parser<'r, 't>,

--- a/src/parse/rule/impls/block/mod.rs
+++ b/src/parse/rule/impls/block/mod.rs
@@ -94,6 +94,8 @@ impl Debug for BlockRule {
         f.debug_struct("BlockRule")
             .field("name", &self.name)
             .field("accepts_names", &self.accepts_names)
+            .field("accepts_special", &self.accepts_special)
+            .field("newline_separator", &self.newline_separator)
             .field("parse_fn", &(self.parse_fn as *const ()))
             .finish()
     }

--- a/src/parse/rule/impls/block/parser.rs
+++ b/src/parse/rule/impls/block/parser.rs
@@ -431,10 +431,8 @@ where
         //
         // It's fine if we're at the end of the input,
         // it could be an empty block type.
-        if self.current().token != Token::InputEnd {
-            if block_rule.newline_separator {
-                self.get_line_break()?;
-            }
+        if self.current().token != Token::InputEnd && block_rule.newline_separator {
+            self.get_line_break()?;
         }
 
         Ok(())

--- a/src/parse/rule/impls/block/parser.rs
+++ b/src/parse/rule/impls/block/parser.rs
@@ -269,6 +269,11 @@ where
     ) -> ParseResult<'r, 't, Vec<Element<'t>>> {
         let mut first = true;
 
+        // Check that the end block is on a new line, if required
+        if block_rule.newline_separator {
+            self.get_line_break()?;
+        }
+
         gather_paragraphs(
             &self.log(),
             self,

--- a/src/parse/rule/impls/block/parser.rs
+++ b/src/parse/rule/impls/block/parser.rs
@@ -263,6 +263,25 @@ where
         }
     }
 
+    fn get_body_elements_paragraphs(
+        &mut self,
+        block_rule: &BlockRule,
+    ) -> ParseResult<'r, 't, Vec<Element<'t>>> {
+        let mut first = true;
+
+        gather_paragraphs(
+            &self.log(),
+            self,
+            self.rule(),
+            Some(move |parser: &mut Parser<'r, 't>| {
+                let result = parser.verify_end_block(first, block_rule);
+                first = false;
+
+                Ok(result.is_some())
+            }),
+        )
+    }
+
     fn get_body_elements_no_paragraphs(
         &mut self,
         block_rule: &BlockRule,
@@ -290,25 +309,6 @@ where
                 self.step()?;
             }
         }
-    }
-
-    fn get_body_elements_paragraphs(
-        &mut self,
-        block_rule: &BlockRule,
-    ) -> ParseResult<'r, 't, Vec<Element<'t>>> {
-        let mut first = true;
-
-        gather_paragraphs(
-            &self.log(),
-            self,
-            self.rule(),
-            Some(move |parser: &mut Parser<'r, 't>| {
-                let result = parser.verify_end_block(first, block_rule);
-                first = false;
-
-                Ok(result.is_some())
-            }),
-        )
     }
 
     // Block argument parsing

--- a/src/preproc/whitespace.rs
+++ b/src/preproc/whitespace.rs
@@ -58,7 +58,8 @@ pub fn substitute(log: &slog::Logger, text: &mut String) {
     // Tabs to spaces
     str_replace(log, text, "\t", "    ");
 
-    // Remove leading and trailing newlines
+    // Remove leading and trailing newlines,
+    // save one at the end
     regex_replace(log, text, &*LEADING_NEWLINES, "");
     regex_replace(log, text, &*TRAILING_NEWLINES, "");
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -71,7 +71,7 @@ impl Test<'_> {
         test
     }
 
-    pub fn run(&self, log: &slog::Logger) {
+    pub fn run(&mut self, log: &slog::Logger) {
         info!(
             &log,
             "Running syntax tree test case";
@@ -86,6 +86,7 @@ impl Test<'_> {
 
         println!("+ {}", self.name);
 
+        crate::preprocess(log, &mut self.input);
         let tokens = crate::tokenize(log, &self.input);
         let result = crate::parse(log, &tokens);
         let (tree, warnings) = result.into();
@@ -177,7 +178,7 @@ fn ast() {
 
     // Run tests
     println!("Running tests:");
-    for test in tests {
+    for mut test in tests {
         test.run(&log);
     }
 }

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -66,6 +66,7 @@ pub enum Element<'t> {
     /// This is an interactable element provided by Wikidot which allows hiding
     /// all of the internal elements until it is opened by clicking, which can
     /// then be re-hidden by clicking again.
+    #[serde(rename_all = "kebab-case")]
     Collapsible {
         elements: Vec<Element<'t>>,
         id: Option<Cow<'t, str>>,

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -68,14 +68,14 @@ pub enum Element<'t> {
     /// then be re-hidden by clicking again.
     Collapsible {
         elements: Vec<Element<'t>>,
+        id: Option<Cow<'t, str>>,
+        class: Option<Cow<'t, str>>,
+        style: Option<Cow<'t, str>>,
         start_open: bool,
         show_text: Option<Cow<'t, str>>,
         hide_text: Option<Cow<'t, str>>,
         show_top: bool,
         show_bottom: bool,
-        id: Option<Cow<'t, str>>,
-        class: Option<Cow<'t, str>>,
-        style: Option<Cow<'t, str>>,
     },
 
     /// Element containing colored text.

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -61,6 +61,23 @@ pub enum Element<'t> {
         anchor: AnchorTarget,
     },
 
+    /// A collapsible, containing content hidden to be opened on click.
+    ///
+    /// This is an interactable element provided by Wikidot which allows hiding
+    /// all of the internal elements until it is opened by clicking, which can
+    /// then be re-hidden by clicking again.
+    Collapsible {
+        elements: Vec<Element<'t>>,
+        start_open: bool,
+        show_text: Option<Cow<'t, str>>,
+        hide_text: Option<Cow<'t, str>>,
+        show_top: bool,
+        show_bottom: bool,
+        id: Option<Cow<'t, str>>,
+        class: Option<Cow<'t, str>>,
+        style: Option<Cow<'t, str>>,
+    },
+
     /// Element containing colored text.
     ///
     /// The CSS designation of the color is specified, followed by the elements contained within.

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -126,6 +126,7 @@ impl Element<'_> {
             Element::Raw(_) => "Raw",
             Element::Email(_) => "Email",
             Element::Link { .. } => "Link",
+            Element::Collapsible { .. } => "Collapsible",
             Element::Color { .. } => "Color",
             Element::Div { .. } => "Div",
             Element::Code { .. } => "Code",

--- a/test/collapsible-empty.json
+++ b/test/collapsible-empty.json
@@ -1,0 +1,34 @@
+{
+    "input": "[[collapsible]]\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-folded-no.json
+++ b/test/collapsible-folded-no.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible folded =\"no\"]]\nCherry\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": true,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Cherry"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-folded-yes.json
+++ b/test/collapsible-folded-yes.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible folded = \"YES\"]]\nCherry\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Cherry"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-location-both.json
+++ b/test/collapsible-location-both.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible HIDELOCATION=\"both\"]]\nCherry\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": true,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Cherry"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-location-bottom.json
+++ b/test/collapsible-location-bottom.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible hideLocation=\"bottom\"]]\nCherry\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": false,
+                                "show-bottom": true,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Cherry"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-location-neither.json
+++ b/test/collapsible-location-neither.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible hidelocation=\"neither\"]]\nCherry\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": false,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Cherry"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-location-top.json
+++ b/test/collapsible-location-top.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible HIDEloCATioN =  \"top\" ]]\nCherry\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Cherry"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-nested-deep.json
+++ b/test/collapsible-nested-deep.json
@@ -1,0 +1,100 @@
+{
+    "input": "[[collapsible]]\nApple\n[[collapsible]]\nBanana\n[[collapsible]]\nCherry\n[[/collapsible]]\n[[/collapsible]]\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Apple"
+                                                },
+                                                {
+                                                    "element": "collapsible",
+                                                    "data": {
+                                                        "id": null,
+                                                        "class": null,
+                                                        "style": null,
+                                                        "start-open": false,
+                                                        "show-text": null,
+                                                        "hide-text": null,
+                                                        "show-top": true,
+                                                        "show-bottom": false,
+                                                        "elements": [
+                                                            {
+                                                                "element": "container",
+                                                                "data": {
+                                                                    "type": "paragraph",
+                                                                    "elements": [
+                                                                        {
+                                                                            "element": "text",
+                                                                            "data": "Banana"
+                                                                        },
+                                                                        {
+                                                                            "element": "collapsible",
+                                                                            "data": {
+                                                                                "id": null,
+                                                                                "class": null,
+                                                                                "style": null,
+                                                                                "start-open": false,
+                                                                                "show-text": null,
+                                                                                "hide-text": null,
+                                                                                "show-top": true,
+                                                                                "show-bottom": false,
+                                                                                "elements": [
+                                                                                    {
+                                                                                        "element": "container",
+                                                                                        "data": {
+                                                                                            "type": "paragraph",
+                                                                                            "elements": [
+                                                                                                {
+                                                                                                    "element": "text",
+                                                                                                    "data": "Cherry"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-nested.json
+++ b/test/collapsible-nested.json
@@ -1,0 +1,73 @@
+{
+    "input": "[[collapsible]]\nApple\n[[collapsible show=\"+ More Fruit\" hide=\"- Hide Fruit\"]]\nBanana\n[[/collapsible]]\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Apple"
+                                                },
+                                                {
+                                                    "element": "collapsible",
+                                                    "data": {
+                                                        "id": null,
+                                                        "class": null,
+                                                        "style": null,
+                                                        "start-open": false,
+                                                        "show-text": "+ More Fruit",
+                                                        "hide-text": "- Hide Fruit",
+                                                        "show-top": true,
+                                                        "show-bottom": false,
+                                                        "elements": [
+                                                            {
+                                                                "element": "container",
+                                                                "data": {
+                                                                    "type": "paragraph",
+                                                                    "elements": [
+                                                                        {
+                                                                            "element": "text",
+                                                                            "data": "Banana"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-styling.json
+++ b/test/collapsible-styling.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible id=\"fruit\" class=\"collapse-list\" style=\"display: inline-block\"]]\nBanana\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": "fruit",
+                                "class": "collapse-list",
+                                "style": "display: inline-block",
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Banana"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-text.json
+++ b/test/collapsible-text.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible show=\"SHOW!\" hide=\"HIDE!\"]]\nApple\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": "SHOW!",
+                                "hide-text": "HIDE!",
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Apple"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible-uppercase.json
+++ b/test/collapsible-uppercase.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[ COLLapsiBLe  ID=\"id\" CLASS = \"class\"  ]]\nCherry\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": "id",
+                                "class": "class",
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Cherry"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/collapsible.json
+++ b/test/collapsible.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible]]\nApple\n[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Apple"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/css-multiple.json
+++ b/test/css-multiple.json
@@ -8,9 +8,6 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "line-break"
-                        },
-                        {
                             "element": "text",
                             "data": "apple"
                         },

--- a/test/line-breaks-alias.json
+++ b/test/line-breaks-alias.json
@@ -18,9 +18,6 @@
                             }
                         },
                         {
-                            "element": "line-break"
-                        },
-                        {
                             "element": "text",
                             "data": "Apple"
                         }

--- a/test/line-breaks-uppercase.json
+++ b/test/line-breaks-uppercase.json
@@ -18,9 +18,6 @@
                             }
                         },
                         {
-                            "element": "line-break"
-                        },
-                        {
                             "element": "text",
                             "data": "Banana"
                         }

--- a/test/line-breaks.json
+++ b/test/line-breaks.json
@@ -18,9 +18,6 @@
                             }
                         },
                         {
-                            "element": "line-break"
-                        },
-                        {
                             "element": "text",
                             "data": "Banana"
                         }

--- a/test/simple-newline.json
+++ b/test/simple-newline.json
@@ -2,17 +2,6 @@
     "input": "\n",
     "tree": {
         "elements": [
-            {
-                "element": "container",
-                "data": {
-                    "type": "paragraph",
-                    "elements": [
-                        {
-                            "element": "line-break"
-                        }
-                    ]
-                }
-            }
         ],
         "styles": [
         ]

--- a/test/simple-space.json
+++ b/test/simple-space.json
@@ -2,18 +2,6 @@
     "input": " ",
     "tree": {
         "elements": [
-            {
-                "element": "container",
-                "data": {
-                    "type": "paragraph",
-                    "elements": [
-                        {
-                            "element": "text",
-                            "data": " "
-                        }
-                    ]
-                }
-            }
         ],
         "styles": [
         ]

--- a/test/spaces.json
+++ b/test/spaces.json
@@ -2,18 +2,6 @@
     "input": "  ",
     "tree": {
         "elements": [
-            {
-                "element": "container",
-                "data": {
-                    "type": "paragraph",
-                    "elements": [
-                        {
-                            "element": "text",
-                            "data": "  "
-                        }
-                    ]
-                }
-            }
         ],
         "styles": [
         ]


### PR DESCRIPTION
Add the `[[collapsible]]` block, which is nestable and supports styling arguments (i.e. `id`, `class`, `style`) like `[[div]]` does.

This also reworks how block heads are parsed a bit, to make working with them more consistent and modular.