### PR TITLE
Add module support

### DIFF
--- a/src/parse/exception.rs
+++ b/src/parse/exception.rs
@@ -115,7 +115,7 @@ pub enum ParseWarningKind {
     /// This block does not allow special invocation.
     InvalidSpecialBlock,
 
-    /// This block does not have a name.
+    /// This block does not specify a name.
     BlockMissingName,
 
     /// This block does not have close brackets when required.
@@ -138,6 +138,9 @@ pub enum ParseWarningKind {
 
     /// This no rule for the module name specified.
     NoSuchModule,
+
+    /// This module does not specify a name.
+    ModuleMissingName,
 
     /// The URL passed here was invalid.
     InvalidUrl,

--- a/src/parse/exception.rs
+++ b/src/parse/exception.rs
@@ -136,6 +136,9 @@ pub enum ParseWarningKind {
     /// An end block was found, but of the incorrect type.
     BlockEndMismatch,
 
+    /// This no rule for the module name specified.
+    NoSuchModule,
+
     /// The URL passed here was invalid.
     InvalidUrl,
 }

--- a/src/parse/rule/impls/block/arguments.rs
+++ b/src/parse/rule/impls/block/arguments.rs
@@ -55,8 +55,8 @@ impl<'t> Arguments<'t> {
 
     pub fn get_bool(
         &mut self,
-        key: &'t str,
         parser: &Parser<'_, 't>,
+        key: &'t str,
     ) -> Result<Option<bool>, ParseWarning> {
         match self.get(key) {
             Some(argument) => match parse_boolean(argument) {
@@ -69,8 +69,8 @@ impl<'t> Arguments<'t> {
 
     pub fn get_value<T: FromStr>(
         &mut self,
-        key: &'t str,
         parser: &Parser<'_, 't>,
+        key: &'t str,
     ) -> Result<Option<T>, ParseWarning> {
         match self.get(key) {
             Some(argument) => match argument.parse() {

--- a/src/parse/rule/impls/block/blocks/code.rs
+++ b/src/parse/rule/impls/block/blocks/code.rs
@@ -38,10 +38,7 @@ fn parse_fn<'r, 't>(
     debug!(log, "Parsing code block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Code doesn't allow special variant");
-    assert!(
-        name.eq_ignore_ascii_case("code"),
-        "Code doesn't have a valid name",
-    );
+    assert_block_name(&BLOCK_CODE, name);
 
     let mut arguments = parser.get_head_map(&BLOCK_CODE, in_head)?;
     let language = arguments.get("type");

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -43,10 +43,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Collapsible doesn't allow special variant");
-    assert!(
-        name.eq_ignore_ascii_case("collapsible"),
-        "Collapsible doesn't have a valid name",
-    );
+    assert_block_name(&BLOCK_COLLAPSIBLE, name);
 
     let mut arguments = parser.get_head_map(&BLOCK_COLLAPSIBLE, in_head)?;
 

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use crate::parse::{parse_boolean, ParseWarning, ParseWarningKind};
+use crate::parse::{ParseWarning, ParseWarningKind};
 
 pub const BLOCK_COLLAPSIBLE: BlockRule = BlockRule {
     name: "block-collapsible",
@@ -57,23 +57,7 @@ fn parse_fn<'r, 't>(
     let hide_text = arguments.get("hide");
 
     // Get folding arguments
-    let start_open = match arguments.get("folded") {
-        Some(value) => {
-            // Parse this argument as bool
-            //
-            // Also invert the result, "folded=yes" means "start_open=no".
-            match parse_boolean(value) {
-                Ok(value) => !value,
-                Err(_) => {
-                    return Err(
-                        parser.make_warn(ParseWarningKind::BlockMalformedArguments)
-                    )
-                }
-            }
-        }
-        None => false,
-    };
-
+    let start_open = arguments.get_bool(parser, "folded")?.unwrap_or(false);
     let (show_top, show_bottom) = match arguments.get("hideLocation") {
         Some(value) => parse_hide_location(&value, parser)?,
         None => (true, false),

--- a/src/parse/rule/impls/block/blocks/collapsible.rs
+++ b/src/parse/rule/impls/block/blocks/collapsible.rs
@@ -57,7 +57,9 @@ fn parse_fn<'r, 't>(
     let hide_text = arguments.get("hide");
 
     // Get folding arguments
-    let start_open = arguments.get_bool(parser, "folded")?.unwrap_or(false);
+    //
+    // We invert this first argument since "folded=no" means "start_open=yes"
+    let start_open = !arguments.get_bool(parser, "folded")?.unwrap_or(true);
     let (show_top, show_bottom) = match arguments.get("hideLocation") {
         Some(value) => parse_hide_location(&value, parser)?,
         None => (true, false),

--- a/src/parse/rule/impls/block/blocks/css.rs
+++ b/src/parse/rule/impls/block/blocks/css.rs
@@ -38,10 +38,7 @@ fn parse_fn<'r, 't>(
     debug!(log, "Parsing CSS block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Code doesn't allow special variant");
-    assert!(
-        name.eq_ignore_ascii_case("css"),
-        "Code doesn't have a valid name",
-    );
+    assert_block_name(&BLOCK_CSS, name);
 
     parser.get_head_none(&BLOCK_CSS, in_head)?;
 

--- a/src/parse/rule/impls/block/blocks/div.rs
+++ b/src/parse/rule/impls/block/blocks/div.rs
@@ -43,6 +43,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Div doesn't allow special variant");
+    assert_block_name(&BLOCK_DIV, name);
 
     let mut arguments = parser.get_head_map(&BLOCK_DIV, in_head)?;
 

--- a/src/parse/rule/impls/block/blocks/lines.rs
+++ b/src/parse/rule/impls/block/blocks/lines.rs
@@ -39,10 +39,7 @@ fn parse_fn<'r, 't>(
     debug!(log, "Parsing newlines block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Code doesn't allow special variant");
-    assert!(
-        name.eq_ignore_ascii_case("lines") || name.eq_ignore_ascii_case("newlines"),
-        "Code doesn't have a valid name",
-    );
+    assert_block_name(&BLOCK_LINES, name);
 
     let count = parser.get_head_value(&BLOCK_LINES, in_head, parse_count)?;
 

--- a/src/parse/rule/impls/block/blocks/lines.rs
+++ b/src/parse/rule/impls/block/blocks/lines.rs
@@ -46,7 +46,7 @@ fn parse_fn<'r, 't>(
 
     let count = parser.get_head_value(&BLOCK_LINES, in_head, parse_count)?;
 
-    ok!(Element::LineBreaks { count })
+    ok!(Element::LineBreaks(count))
 }
 
 fn parse_count<'r, 't>(

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -28,7 +28,7 @@ mod prelude {
     pub use crate::tree::Element;
 
     #[doc(hidden)]
-    pub fn check_generic_name(expected_names: &[&str], actual_name: &str, name_type: &str) {
+    pub fn assert_generic_name(expected_names: &[&str], actual_name: &str, name_type: &str) {
         for name in expected_names {
             if name.eq_ignore_ascii_case(actual_name) {
                 return;
@@ -44,8 +44,8 @@ mod prelude {
     }
 
     #[inline]
-    pub fn check_block_name(expected_names: &[&str], actual_name: &str) {
-        check_generic_name(expected_names, actual_name, "block")
+    pub fn assert_block_name(expected_names: &[&str], actual_name: &str) {
+        assert_generic_name(expected_names, actual_name, "block")
     }
 }
 

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -28,7 +28,11 @@ mod prelude {
     pub use crate::tree::Element;
 
     #[cfg(debug)]
-    pub fn assert_generic_name(expected_names: &[&str], actual_name: &str, name_type: &str) {
+    pub fn assert_generic_name(
+        expected_names: &[&str],
+        actual_name: &str,
+        name_type: &str,
+    ) {
         for name in expected_names {
             if name.eq_ignore_ascii_case(actual_name) {
                 return;
@@ -37,9 +41,7 @@ mod prelude {
 
         panic!(
             "Actual {} name doesn't match any expected: {:?} (was {})",
-            name_type,
-            expected_names,
-            actual_name,
+            name_type, expected_names, actual_name,
         );
     }
 

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -26,6 +26,26 @@ mod prelude {
     pub use crate::parse::prelude::*;
     pub use crate::parse::{ParseWarning, Token};
     pub use crate::tree::Element;
+
+    pub fn check_generic_name(expected_names: &[&str], actual_name: &str, name_type: &str) {
+        for name in expected_names {
+            if name.eq_ignore_ascii_case(actual_name) {
+                return;
+            }
+        }
+
+        panic!(
+            "Actual {} name doesn't match any expected: {:?} (was {})",
+            name_type,
+            expected_names,
+            actual_name,
+        );
+    }
+
+    #[inline]
+    pub fn check_block_name(expected_names: &[&str], actual_name: &str) {
+        check_generic_name(expected_names, actual_name, "block")
+    }
 }
 
 mod code;

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -27,6 +27,7 @@ mod prelude {
     pub use crate::parse::{ParseWarning, Token};
     pub use crate::tree::Element;
 
+    #[doc(hidden)]
     pub fn check_generic_name(expected_names: &[&str], actual_name: &str, name_type: &str) {
         for name in expected_names {
             if name.eq_ignore_ascii_case(actual_name) {

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -27,7 +27,7 @@ mod prelude {
     pub use crate::parse::{ParseWarning, Token};
     pub use crate::tree::Element;
 
-    #[doc(hidden)]
+    #[cfg(debug)]
     pub fn assert_generic_name(expected_names: &[&str], actual_name: &str, name_type: &str) {
         for name in expected_names {
             if name.eq_ignore_ascii_case(actual_name) {
@@ -42,6 +42,9 @@ mod prelude {
             actual_name,
         );
     }
+
+    #[cfg(not(debug))]
+    pub fn assert_generic_name(_: &[&str], _: &str, _: &str) {}
 
     #[inline]
     pub fn assert_block_name(block_rule: &BlockRule, actual_name: &str) {

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -44,8 +44,8 @@ mod prelude {
     }
 
     #[inline]
-    pub fn assert_block_name(expected_names: &[&str], actual_name: &str) {
-        assert_generic_name(expected_names, actual_name, "block")
+    pub fn assert_block_name(block_rule: &BlockRule, actual_name: &str) {
+        assert_generic_name(block_rule.accepts_names, actual_name, "block")
     }
 }
 

--- a/src/parse/rule/impls/block/blocks/module/mapping.rs
+++ b/src/parse/rule/impls/block/blocks/module/mapping.rs
@@ -1,0 +1,72 @@
+/*
+ * parse/rule/impls/block/blocks/module/mapping.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::{modules::*, ModuleRule};
+use std::collections::HashMap;
+use unicase::UniCase;
+
+pub const MODULE_RULES: [ModuleRule; 0] = [];
+
+pub type ModuleRuleMap = HashMap<UniCase<&'static str>, &'static ModuleRule>;
+
+lazy_static! {
+    pub static ref MODULE_RULE_MAP: ModuleRuleMap = build_module_rule_map(&MODULE_RULES);
+}
+
+#[inline]
+pub fn get_module_rule_with_name(name: &str) -> Option<&'static ModuleRule> {
+    let name = UniCase::ascii(name);
+
+    MODULE_RULE_MAP.get(&name).copied()
+}
+
+fn build_module_rule_map(module_rules: &'static [ModuleRule]) -> ModuleRuleMap {
+    let mut map = HashMap::new();
+
+    for module_rule in module_rules {
+        assert!(
+            module_rule.name.starts_with("module-"),
+            "Module name does not start with 'module-'.",
+        );
+
+        assert_eq!(
+            module_rule.accepts_names.is_empty(),
+            false,
+            "Module has no accepted names",
+        );
+
+        for name in module_rule.accepts_names {
+            let name = UniCase::ascii(*name);
+            let previous = map.insert(name, module_rule);
+
+            assert!(
+                previous.is_none(),
+                "Overwrote previous module rule during rule population!",
+            );
+        }
+    }
+
+    map
+}
+
+#[test]
+fn module_rule_map() {
+    let _ = &*MODULE_RULE_MAP;
+}

--- a/src/parse/rule/impls/block/blocks/module/mapping.rs
+++ b/src/parse/rule/impls/block/blocks/module/mapping.rs
@@ -22,7 +22,14 @@ use super::{modules::*, ModuleRule};
 use std::collections::HashMap;
 use unicase::UniCase;
 
-pub const MODULE_RULES: [ModuleRule; 0] = [];
+pub const MODULE_RULES: [ModuleRule; 6] = [
+    MODULE_BACKLINKS,
+    MODULE_CATEGORIES,
+    MODULE_CSS,
+    MODULE_JOIN,
+    MODULE_PAGE_TREE,
+    MODULE_RATE,
+];
 
 pub type ModuleRuleMap = HashMap<UniCase<&'static str>, &'static ModuleRule>;
 

--- a/src/parse/rule/impls/block/blocks/module/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/mod.rs
@@ -27,7 +27,7 @@ use super::prelude;
 use crate::parse::rule::impls::block::Arguments;
 use crate::parse::rule::Rule;
 use crate::parse::{ParseResult, Parser};
-use crate::tree::Element;
+use crate::tree::{Element, Module};
 use std::fmt::{self, Debug};
 
 pub use self::rule::BLOCK_MODULE;
@@ -88,9 +88,10 @@ impl Debug for ModuleRule {
 /// * `log` -- `slog::Logger` instance
 /// * `parser` -- `Parser` instance
 /// * `name` -- The name of this module
+/// * `arguments` -- The arguments passed into the module
 pub type ModuleParseFn = for<'r, 't> fn(
     &slog::Logger,
     &mut Parser<'r, 't>,
     &'t str,
     Arguments<'t>,
-) -> ParseResult<'r, 't, Element<'t>>;
+) -> ParseResult<'r, 't, Module<'t>>;

--- a/src/parse/rule/impls/block/blocks/module/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/mod.rs
@@ -20,9 +20,12 @@
 
 mod mapping;
 mod modules;
+mod parser;
 mod rule;
 
 use super::prelude;
+use crate::parse::rule::impls::block::Arguments;
+use crate::parse::rule::Rule;
 use crate::parse::{ParseResult, Parser};
 use crate::tree::Element;
 use std::fmt::{self, Debug};
@@ -46,6 +49,27 @@ pub struct ModuleRule {
 
     /// Function which implements the processing for this rule.
     parse_fn: ModuleParseFn,
+}
+
+impl ModuleRule {
+    /// Produces a pseudo parse `Rule` associated with this `BlockRule`.
+    ///
+    /// It should not be invoked, it is for warning construction.
+    #[cold]
+    pub fn rule(&self) -> Rule {
+        // Stubbed try_consume_fn implementation for the Rule.
+        fn try_consume_fn<'p, 'r, 't>(
+            _: &slog::Logger,
+            _: &'p mut Parser<'r, 't>,
+        ) -> ParseResult<'r, 't, Element<'t>> {
+            panic!("Pseudo rule for this module should not be executed directly!");
+        }
+
+        Rule {
+            name: self.name,
+            try_consume_fn,
+        }
+    }
 }
 
 impl Debug for ModuleRule {

--- a/src/parse/rule/impls/block/blocks/module/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/mod.rs
@@ -68,4 +68,5 @@ pub type ModuleParseFn = for<'r, 't> fn(
     &slog::Logger,
     &mut Parser<'r, 't>,
     &'t str,
+    Arguments<'t>,
 ) -> ParseResult<'r, 't, Element<'t>>;

--- a/src/parse/rule/impls/block/blocks/module/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/mod.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/block/blocks/mod.rs
+ * parse/rule/impls/block/blocks/module/mod.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Ammon Smith
@@ -18,26 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use super::super::{Arguments, BlockRule};
-    pub use crate::parse::collect::*;
-    pub use crate::parse::condition::ParseCondition;
-    pub use crate::parse::parser::Parser;
-    pub use crate::parse::prelude::*;
-    pub use crate::parse::{ParseWarning, Token};
-    pub use crate::tree::Element;
-}
+mod modules;
+mod rule;
 
-mod code;
-mod collapsible;
-mod css;
-mod div;
-mod lines;
-mod module;
+use super::prelude;
 
-pub use self::code::BLOCK_CODE;
-pub use self::collapsible::BLOCK_COLLAPSIBLE;
-pub use self::css::BLOCK_CSS;
-pub use self::div::BLOCK_DIV;
-pub use self::lines::BLOCK_LINES;
-pub use self::module::BLOCK_MODULE;
+pub use self::rule::BLOCK_MODULE;

--- a/src/parse/rule/impls/block/blocks/module/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/mod.rs
@@ -18,9 +18,54 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+mod mapping;
 mod modules;
 mod rule;
 
 use super::prelude;
+use crate::parse::{ParseResult, Parser};
+use crate::tree::Element;
+use std::fmt::{self, Debug};
 
 pub use self::rule::BLOCK_MODULE;
+
+/// Define a rule for how to parse a module.
+#[derive(Clone)]
+pub struct ModuleRule {
+    /// The code name of the module.
+    ///
+    /// As this is an internal structure, we can assert the following things:
+    /// * It is in kebab-case.
+    /// * It is globally unique.
+    /// * It is prefixed with `module-`.
+    name: &'static str,
+
+    /// Which names you can use this module with. Case-insensitive.
+    /// Will panic if empty.
+    accepts_names: &'static [&'static str],
+
+    /// Function which implements the processing for this rule.
+    parse_fn: ModuleParseFn,
+}
+
+impl Debug for ModuleRule {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ModuleRule")
+            .field("name", &self.name)
+            .field("accepts_names", &self.accepts_names)
+            .field("parse_fn", &(self.parse_fn as *const ()))
+            .finish()
+    }
+}
+
+/// Function pointer type to implement module parsing.
+///
+/// The arguments are, in order:
+/// * `log` -- `slog::Logger` instance
+/// * `parser` -- `Parser` instance
+/// * `name` -- The name of this module
+pub type ModuleParseFn = for<'r, 't> fn(
+    &slog::Logger,
+    &mut Parser<'r, 't>,
+    &'t str,
+) -> ParseResult<'r, 't, Element<'t>>;

--- a/src/parse/rule/impls/block/blocks/module/modules/backlinks.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/backlinks.rs
@@ -28,7 +28,7 @@ pub const MODULE_BACKLINKS: ModuleRule = ModuleRule {
 
 fn parse_fn<'r, 't>(
     log: &slog::Logger,
-    parser: &mut Parser<'r, 't>,
+    _parser: &mut Parser<'r, 't>,
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Module<'t>> {

--- a/src/parse/rule/impls/block/blocks/module/modules/backlinks.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/backlinks.rs
@@ -33,11 +33,7 @@ fn parse_fn<'r, 't>(
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Module<'t>> {
     debug!(log, "Parsing backlinks module");
-
-    assert!(
-        name.eq_ignore_ascii_case("Backlinks"),
-        "Module doesn't have a valid name",
-    );
+    assert_module_name(&MODULE_BACKLINKS, name);
 
     let page = arguments.get("page");
 

--- a/src/parse/rule/impls/block/blocks/module/modules/backlinks.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/backlinks.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/block/blocks/module/modules/mod.rs
+ * parse/rule/impls/block/blocks/module/modules/backlinks.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Ammon Smith
@@ -18,9 +18,28 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use super::super::{prelude::*, ModuleRule};
-    pub use crate::tree::Module;
-}
+use super::prelude::*;
 
-mod backlinks;
+pub const MODULE_BACKLINKS: ModuleRule = ModuleRule {
+    name: "module-backlinks",
+    accepts_names: &["Backlinks"],
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    mut arguments: Arguments<'t>,
+) -> ParseResult<'r, 't, Module<'t>> {
+    debug!(log, "Parsing backlinks module");
+
+    assert!(
+        name.eq_ignore_ascii_case("Backlinks"),
+        "Module doesn't have a valid name",
+    );
+
+    let page = arguments.get("page");
+
+    ok!(Module::Backlinks { page })
+}

--- a/src/parse/rule/impls/block/blocks/module/modules/categories.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/categories.rs
@@ -1,0 +1,50 @@
+/*
+ * parse/rule/impls/block/blocks/module/modules/categories.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+use crate::parse::parse_boolean;
+
+pub const MODULE_CATEGORIES: ModuleRule = ModuleRule {
+    name: "module-categories",
+    accepts_names: &["Categories"],
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    mut arguments: Arguments<'t>,
+) -> ParseResult<'r, 't, Module<'t>> {
+    debug!(log, "Parsing categories module");
+
+    assert!(
+        name.eq_ignore_ascii_case("Categories"),
+        "Module doesn't have a valid name",
+    );
+
+    let include_hidden = match arguments.get("includeHidden") {
+        Some(value) => parse_boolean(value)
+            .map_err(|_| parser.make_warn(ParseWarningKind::BlockMalformedArguments))?,
+        None => false,
+    };
+
+    ok!(Module::Categories { include_hidden })
+}

--- a/src/parse/rule/impls/block/blocks/module/modules/categories.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/categories.rs
@@ -34,11 +34,7 @@ fn parse_fn<'r, 't>(
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Module<'t>> {
     debug!(log, "Parsing categories module");
-
-    assert!(
-        name.eq_ignore_ascii_case("Categories"),
-        "Module doesn't have a valid name",
-    );
+    assert_module_name(&MODULE_CATEGORIES, name);
 
     let include_hidden = match arguments.get("includeHidden") {
         Some(value) => parse_boolean(value)

--- a/src/parse/rule/impls/block/blocks/module/modules/categories.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/categories.rs
@@ -19,7 +19,6 @@
  */
 
 use super::prelude::*;
-use crate::parse::parse_boolean;
 
 pub const MODULE_CATEGORIES: ModuleRule = ModuleRule {
     name: "module-categories",
@@ -36,11 +35,9 @@ fn parse_fn<'r, 't>(
     debug!(log, "Parsing categories module");
     assert_module_name(&MODULE_CATEGORIES, name);
 
-    let include_hidden = match arguments.get("includeHidden") {
-        Some(value) => parse_boolean(value)
-            .map_err(|_| parser.make_warn(ParseWarningKind::BlockMalformedArguments))?,
-        None => false,
-    };
+    let include_hidden = arguments
+        .get_bool(parser, "includeHidden")?
+        .unwrap_or(false);
 
     ok!(Module::Categories { include_hidden })
 }

--- a/src/parse/rule/impls/block/blocks/module/modules/css.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/css.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/block/blocks/module/modules/mod.rs
+ * parse/rule/impls/block/blocks/module/modules/css.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Ammon Smith
@@ -18,11 +18,29 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use super::super::{prelude::*, ModuleRule, BLOCK_MODULE};
-    pub use crate::tree::Module;
-}
+use super::prelude::*;
 
-mod backlinks;
-mod categories;
-mod css;
+pub const MODULE_CSS: ModuleRule = ModuleRule {
+    name: "module-css",
+    accepts_names: &["CSS"],
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    arguments: Arguments<'t>,
+) -> ParseResult<'r, 't, Module<'t>> {
+    debug!(log, "Parsing categories module");
+
+    assert!(
+        name.eq_ignore_ascii_case("Categories"),
+        "Module doesn't have a valid name",
+    );
+
+    let css = parser.get_body_text(&BLOCK_MODULE)?;
+    let exceptions = vec![ParseException::Style(cow!(css))];
+
+    ok!(Module::Null, exceptions)
+}

--- a/src/parse/rule/impls/block/blocks/module/modules/css.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/css.rs
@@ -33,11 +33,7 @@ fn parse_fn<'r, 't>(
     _arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Module<'t>> {
     debug!(log, "Parsing categories module");
-
-    assert!(
-        name.eq_ignore_ascii_case("CSS"),
-        "Module doesn't have a valid name",
-    );
+    assert_module_name(&MODULE_CSS, name);
 
     let css = parser.get_body_text(&BLOCK_MODULE)?;
     let exceptions = vec![ParseException::Style(cow!(css))];

--- a/src/parse/rule/impls/block/blocks/module/modules/join.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/join.rs
@@ -34,11 +34,7 @@ fn parse_fn<'r, 't>(
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Module<'t>> {
     debug!(log, "Parsing join module");
-
-    assert!(
-        name.eq_ignore_ascii_case("Join"),
-        "Module doesn't have a valid name",
-    );
+    assert_module_name(&MODULE_JOIN, name);
 
     let button_text = arguments.get("button");
     let id = arguments.get("id");

--- a/src/parse/rule/impls/block/blocks/module/modules/join.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/join.rs
@@ -19,7 +19,6 @@
  */
 
 use super::prelude::*;
-use crate::parse::parse_boolean;
 
 pub const MODULE_JOIN: ModuleRule = ModuleRule {
     name: "module-join",

--- a/src/parse/rule/impls/block/blocks/module/modules/join.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/join.rs
@@ -1,0 +1,54 @@
+/*
+ * parse/rule/impls/block/blocks/module/modules/join.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+use crate::parse::parse_boolean;
+
+pub const MODULE_JOIN: ModuleRule = ModuleRule {
+    name: "module-join",
+    accepts_names: &["Join"],
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    mut arguments: Arguments<'t>,
+) -> ParseResult<'r, 't, Module<'t>> {
+    debug!(log, "Parsing join module");
+
+    assert!(
+        name.eq_ignore_ascii_case("Join"),
+        "Module doesn't have a valid name",
+    );
+
+    let button_text = arguments.get("button");
+    let id = arguments.get("id");
+    let class = arguments.get("class");
+    let style = arguments.get("style");
+
+    ok!(Module::Join {
+        button_text,
+        id,
+        class,
+        style
+    })
+}

--- a/src/parse/rule/impls/block/blocks/module/modules/join.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/join.rs
@@ -28,7 +28,7 @@ pub const MODULE_JOIN: ModuleRule = ModuleRule {
 
 fn parse_fn<'r, 't>(
     log: &slog::Logger,
-    parser: &mut Parser<'r, 't>,
+    _parser: &mut Parser<'r, 't>,
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Module<'t>> {

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -18,4 +18,4 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+// TODO

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -23,8 +23,8 @@ mod prelude {
     pub use crate::tree::Module;
 
     #[inline]
-    pub fn assert_module_name(expected_names: &[&str], actual_name: &str) {
-        assert_generic_name(expected_names, actual_name, "module")
+    pub fn assert_module_name(module_rule: &ModuleRule, actual_name: &str) {
+        assert_generic_name(module_rule.accepts_names, actual_name, "module")
     }
 }
 

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -21,6 +21,11 @@
 mod prelude {
     pub use super::super::{prelude::*, ModuleRule, BLOCK_MODULE};
     pub use crate::tree::Module;
+
+    #[inline]
+    pub fn check_module_name(expected_names: &[&str], actual_name: &str) {
+        check_generic_name(expected_names, actual_name, "module")
+    }
 }
 
 mod backlinks;

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -26,4 +26,5 @@ mod prelude {
 mod backlinks;
 mod categories;
 mod css;
+mod join;
 mod rate;

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -29,3 +29,10 @@ mod css;
 mod join;
 mod page_tree;
 mod rate;
+
+pub use self::backlinks::MODULE_BACKLINKS;
+pub use self::categories::MODULE_CATEGORIES;
+pub use self::css::MODULE_CSS;
+pub use self::join::MODULE_JOIN;
+pub use self::page_tree::MODULE_PAGE_TREE;
+pub use self::rate::MODULE_RATE;

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/block/blocks/mod.rs
+ * parse/rule/impls/block/blocks/module/modules/mod.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Ammon Smith
@@ -18,26 +18,4 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod prelude {
-    pub use super::super::{Arguments, BlockRule};
-    pub use crate::parse::collect::*;
-    pub use crate::parse::condition::ParseCondition;
-    pub use crate::parse::parser::Parser;
-    pub use crate::parse::prelude::*;
-    pub use crate::parse::{ParseWarning, Token};
-    pub use crate::tree::Element;
-}
 
-mod code;
-mod collapsible;
-mod css;
-mod div;
-mod lines;
-mod module;
-
-pub use self::code::BLOCK_CODE;
-pub use self::collapsible::BLOCK_COLLAPSIBLE;
-pub use self::css::BLOCK_CSS;
-pub use self::div::BLOCK_DIV;
-pub use self::lines::BLOCK_LINES;
-pub use self::module::BLOCK_MODULE;

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -26,3 +26,4 @@ mod prelude {
 mod backlinks;
 mod categories;
 mod css;
+mod rate;

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -24,3 +24,4 @@ mod prelude {
 }
 
 mod backlinks;
+mod categories;

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -23,8 +23,8 @@ mod prelude {
     pub use crate::tree::Module;
 
     #[inline]
-    pub fn check_module_name(expected_names: &[&str], actual_name: &str) {
-        check_generic_name(expected_names, actual_name, "module")
+    pub fn assert_module_name(expected_names: &[&str], actual_name: &str) {
+        assert_generic_name(expected_names, actual_name, "module")
     }
 }
 

--- a/src/parse/rule/impls/block/blocks/module/modules/mod.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/mod.rs
@@ -27,4 +27,5 @@ mod backlinks;
 mod categories;
 mod css;
 mod join;
+mod page_tree;
 mod rate;

--- a/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -37,9 +37,7 @@ fn parse_fn<'r, 't>(
 
     let root = arguments.get("root");
     let depth = arguments.get_value(parser, "depth")?;
-    let show_root = arguments
-        .get_bool(parser, "showRoot")?
-        .unwrap_or(false);
+    let show_root = arguments.get_bool(parser, "showRoot")?.unwrap_or(false);
 
     ok!(Module::PageTree {
         root,

--- a/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -36,11 +36,10 @@ fn parse_fn<'r, 't>(
     assert_module_name(&MODULE_PAGE_TREE, name);
 
     let root = arguments.get("root");
-
+    let depth = arguments.get_value(parser, "depth")?;
     let show_root = arguments
         .get_bool(parser, "includeHidden")?
         .unwrap_or(false);
-    let depth = arguments.get_value(parser, "depth")?;
 
     ok!(Module::PageTree {
         root,

--- a/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -34,11 +34,7 @@ fn parse_fn<'r, 't>(
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Module<'t>> {
     debug!(log, "Parsing PageTree module");
-
-    assert!(
-        name.eq_ignore_ascii_case("PageTree"),
-        "Module doesn't have a valid name",
-    );
+    assert_module_name(&MODULE_PAGE_TREE, name);
 
     let root = arguments.get("root");
 

--- a/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -19,7 +19,6 @@
  */
 
 use super::prelude::*;
-use crate::parse::parse_boolean;
 
 pub const MODULE_PAGE_TREE: ModuleRule = ModuleRule {
     name: "module-page-tree",
@@ -38,22 +37,10 @@ fn parse_fn<'r, 't>(
 
     let root = arguments.get("root");
 
-    let show_root = match arguments.get("includeHidden") {
-        Some(value) => parse_boolean(value)
-            .map_err(|_| parser.make_warn(ParseWarningKind::BlockMalformedArguments))?,
-        None => false,
-    };
-
-    let depth = match arguments.get("depth") {
-        Some(value) => {
-            let depth = value.as_ref().parse().map_err(|_| {
-                parser.make_warn(ParseWarningKind::BlockMalformedArguments)
-            })?;
-
-            Some(depth)
-        }
-        None => None,
-    };
+    let show_root = arguments
+        .get_bool(parser, "includeHidden")?
+        .unwrap_or(false);
+    let depth = arguments.get_value(parser, "depth")?;
 
     ok!(Module::PageTree {
         root,

--- a/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -1,0 +1,67 @@
+/*
+ * parse/rule/impls/block/blocks/module/modules/page_tree.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+use crate::parse::parse_boolean;
+
+pub const MODULE_PAGE_TREE: ModuleRule = ModuleRule {
+    name: "module-page-tree",
+    accepts_names: &["PageTree"],
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    mut arguments: Arguments<'t>,
+) -> ParseResult<'r, 't, Module<'t>> {
+    debug!(log, "Parsing PageTree module");
+
+    assert!(
+        name.eq_ignore_ascii_case("PageTree"),
+        "Module doesn't have a valid name",
+    );
+
+    let root = arguments.get("root");
+
+    let show_root = match arguments.get("includeHidden") {
+        Some(value) => parse_boolean(value)
+            .map_err(|_| parser.make_warn(ParseWarningKind::BlockMalformedArguments))?,
+        None => false,
+    };
+
+    let depth = match arguments.get("depth") {
+        Some(value) => {
+            let depth = value.as_ref().parse().map_err(|_| {
+                parser.make_warn(ParseWarningKind::BlockMalformedArguments)
+            })?;
+
+            Some(depth)
+        }
+        None => None,
+    };
+
+    ok!(Module::PageTree {
+        root,
+        show_root,
+        depth
+    })
+}

--- a/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     let root = arguments.get("root");
     let depth = arguments.get_value(parser, "depth")?;
     let show_root = arguments
-        .get_bool(parser, "includeHidden")?
+        .get_bool(parser, "showRoot")?
         .unwrap_or(false);
 
     ok!(Module::PageTree {

--- a/src/parse/rule/impls/block/blocks/module/modules/rate.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/rate.rs
@@ -33,11 +33,7 @@ fn parse_fn<'r, 't>(
     _arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Module<'t>> {
     debug!(log, "Parsing categories module");
-
-    assert!(
-        name.eq_ignore_ascii_case("Rate"),
-        "Module doesn't have a valid name",
-    );
+    assert_module_name(&MODULE_RATE, name);
 
     ok!(Module::Rate)
 }

--- a/src/parse/rule/impls/block/blocks/module/modules/rate.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/rate.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/block/blocks/module/modules/css.rs
+ * parse/rule/impls/block/blocks/module/modules/rate.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Ammon Smith
@@ -20,9 +20,9 @@
 
 use super::prelude::*;
 
-pub const MODULE_CSS: ModuleRule = ModuleRule {
-    name: "module-css",
-    accepts_names: &["CSS"],
+pub const MODULE_RATE: ModuleRule = ModuleRule {
+    name: "module-rate",
+    accepts_names: &["Rate"],
     parse_fn,
 };
 
@@ -35,12 +35,9 @@ fn parse_fn<'r, 't>(
     debug!(log, "Parsing categories module");
 
     assert!(
-        name.eq_ignore_ascii_case("CSS"),
+        name.eq_ignore_ascii_case("Rate"),
         "Module doesn't have a valid name",
     );
 
-    let css = parser.get_body_text(&BLOCK_MODULE)?;
-    let exceptions = vec![ParseException::Style(cow!(css))];
-
-    ok!(Module::Null, exceptions)
+    ok!(Module::Rate)
 }

--- a/src/parse/rule/impls/block/blocks/module/modules/rate.rs
+++ b/src/parse/rule/impls/block/blocks/module/modules/rate.rs
@@ -28,7 +28,7 @@ pub const MODULE_RATE: ModuleRule = ModuleRule {
 
 fn parse_fn<'r, 't>(
     log: &slog::Logger,
-    parser: &mut Parser<'r, 't>,
+    _parser: &mut Parser<'r, 't>,
     name: &'t str,
     _arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Module<'t>> {

--- a/src/parse/rule/impls/block/blocks/module/parser.rs
+++ b/src/parse/rule/impls/block/blocks/module/parser.rs
@@ -1,0 +1,38 @@
+/*
+ * parse/rule/impls/block/blocks/module/parser.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::ModuleRule;
+use crate::parse::Parser;
+
+impl<'r, 't> Parser<'r, 't>
+where
+    'r: 't,
+{
+    #[inline]
+    pub fn set_module(&mut self, module_rule: &ModuleRule) {
+        info!(
+            &self.log(),
+            "Running module rule {} for these tokens",
+            module_rule.name;
+        );
+
+        self.set_rule(module_rule.rule());
+    }
+}

--- a/src/parse/rule/impls/block/blocks/module/rule.rs
+++ b/src/parse/rule/impls/block/blocks/module/rule.rs
@@ -1,0 +1,49 @@
+/*
+ * parse/rule/impls/block/blocks/module/rule.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+
+pub const BLOCK_MODULE: BlockRule = BlockRule {
+    name: "block-module",
+    accepts_names: &["module"],
+    accepts_special: false,
+    newline_separator: true,
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    special: bool,
+    in_head: bool,
+) -> ParseResult<'r, 't, Element<'t>> {
+    debug!(log, "Parsing module block"; "in-head" => in_head);
+
+    assert_eq!(special, false, "Module doesn't allow special variant");
+    assert!(
+        name.eq_ignore_ascii_case("module"),
+        "Module doesn't have valid name",
+    );
+
+    let (subname, arguments) = parser.get_head_name_map(&BLOCK_MODULE, in_head)?;
+
+    todo!()
+}

--- a/src/parse/rule/impls/block/blocks/module/rule.rs
+++ b/src/parse/rule/impls/block/blocks/module/rule.rs
@@ -40,10 +40,7 @@ fn parse_fn<'r, 't>(
     debug!(log, "Parsing module block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Module doesn't allow special variant");
-    assert!(
-        name.eq_ignore_ascii_case("module"),
-        "Module doesn't have valid name",
-    );
+    assert_block_name(&BLOCK_MODULE, name);
 
     // Get module name and arguments
     let (subname, arguments) = parser.get_head_name_map(&BLOCK_MODULE, in_head)?;

--- a/src/parse/rule/impls/block/blocks/module/rule.rs
+++ b/src/parse/rule/impls/block/blocks/module/rule.rs
@@ -61,5 +61,8 @@ fn parse_fn<'r, 't>(
     //
     // If the module accepts a body, it should consume it,
     // then the tail. Otherwise it shouldn't move the token pointer.
-    (module.parse_fn)(log, parser, subname, arguments)
+    let (module_ast, exceptions) = (module.parse_fn)(log, parser, subname, arguments)?.into();
+
+    // Build the element
+    ok!(Element::Module(module_ast), exceptions)
 }

--- a/src/parse/rule/impls/block/blocks/module/rule.rs
+++ b/src/parse/rule/impls/block/blocks/module/rule.rs
@@ -23,7 +23,7 @@ use super::prelude::*;
 
 pub const BLOCK_MODULE: BlockRule = BlockRule {
     name: "block-module",
-    accepts_names: &["module"],
+    accepts_names: &["module", "module654"],
     accepts_special: false,
     newline_separator: true,
     parse_fn,

--- a/src/parse/rule/impls/block/blocks/module/rule.rs
+++ b/src/parse/rule/impls/block/blocks/module/rule.rs
@@ -20,6 +20,7 @@
 
 use super::mapping::get_module_rule_with_name;
 use super::prelude::*;
+use crate::tree::Module;
 
 pub const BLOCK_MODULE: BlockRule = BlockRule {
     name: "block-module",
@@ -64,6 +65,13 @@ fn parse_fn<'r, 't>(
     let (module, exceptions) =
         (module_rule.parse_fn)(log, parser, subname, arguments)?.into();
 
-    // Build the element
-    ok!(Element::Module(module), exceptions)
+    ok!(build_element(module), exceptions)
+}
+
+fn build_element(module: Module) -> Element {
+    if module == Module::Null {
+        Element::Null
+    } else {
+        Element::Module(module)
+    }
 }

--- a/src/parse/rule/impls/block/blocks/module/rule.rs
+++ b/src/parse/rule/impls/block/blocks/module/rule.rs
@@ -48,21 +48,21 @@ fn parse_fn<'r, 't>(
     let (subname, arguments) = parser.get_head_name_map(&BLOCK_MODULE, in_head)?;
 
     // Get the module rule for this name
-    let module = match get_module_rule_with_name(subname) {
-        Some(module) => module,
+    let module_rule = match get_module_rule_with_name(subname) {
+        Some(rule) => rule,
         None => return Err(parser.make_warn(ParseWarningKind::NoSuchModule)),
     };
 
     // Prepare to run the module's parsing function
-    parser.set_module(module);
+    parser.set_module(module_rule);
 
     // Run the parse function until the end.
     // This starts after the head and its newline.
     //
     // If the module accepts a body, it should consume it,
     // then the tail. Otherwise it shouldn't move the token pointer.
-    let (module_ast, exceptions) = (module.parse_fn)(log, parser, subname, arguments)?.into();
+    let (module, exceptions) = (module_rule.parse_fn)(log, parser, subname, arguments)?.into();
 
     // Build the element
-    ok!(Element::Module(module_ast), exceptions)
+    ok!(Element::Module(module), exceptions)
 }

--- a/src/parse/rule/impls/block/blocks/module/rule.rs
+++ b/src/parse/rule/impls/block/blocks/module/rule.rs
@@ -61,7 +61,8 @@ fn parse_fn<'r, 't>(
     //
     // If the module accepts a body, it should consume it,
     // then the tail. Otherwise it shouldn't move the token pointer.
-    let (module, exceptions) = (module_rule.parse_fn)(log, parser, subname, arguments)?.into();
+    let (module, exceptions) =
+        (module_rule.parse_fn)(log, parser, subname, arguments)?.into();
 
     // Build the element
     ok!(Element::Module(module), exceptions)

--- a/src/parse/rule/impls/block/mapping.rs
+++ b/src/parse/rule/impls/block/mapping.rs
@@ -22,12 +22,13 @@ use super::{blocks::*, BlockRule};
 use std::collections::HashMap;
 use unicase::UniCase;
 
-pub const BLOCK_RULES: [BlockRule; 5] = [
+pub const BLOCK_RULES: [BlockRule; 6] = [
     BLOCK_CODE,
     BLOCK_COLLAPSIBLE,
     BLOCK_CSS,
     BLOCK_DIV,
     BLOCK_LINES,
+    BLOCK_MODULE,
 ];
 
 pub type BlockRuleMap = HashMap<UniCase<&'static str>, &'static BlockRule>;

--- a/src/parse/rule/impls/block/mod.rs
+++ b/src/parse/rule/impls/block/mod.rs
@@ -104,8 +104,8 @@ impl Debug for BlockRule {
 /// Function pointer type to implement block parsing.
 ///
 /// The arguments are, in order:
-/// * `log` -- Logger instance
-/// * `parser` -- Parser instance
+/// * `log` -- `slog::Logger` instance
+/// * `parser` -- `Parser` instance
 /// * `name` -- The name of the block
 /// * `special` -- Whether this block is `[[*` (special) or `[[` (regular)
 /// * `in_head` -- Whether we're still in the block head, or if it's finished

--- a/src/parse/rule/impls/block/parser.rs
+++ b/src/parse/rule/impls/block/parser.rs
@@ -357,6 +357,43 @@ where
         Ok(map)
     }
 
+    pub fn get_head_name_map(
+        &mut self,
+        block_rule: &BlockRule,
+        in_head: bool,
+    ) -> Result<(&'t str, Arguments<'t>), ParseWarning> {
+        debug!(
+            &self.log(),
+            "Looking for a name, then key value arguments, then ']]'"
+        );
+
+        if !in_head {
+            debug!(
+                &self.log(),
+                "Block is already over, there is no name or arguments",
+            );
+
+            return Err(self.make_warn(ParseWarningKind::BlockMissingArguments));
+        }
+
+        let subname = collect_text(
+            &self.log(),
+            self,
+            self.rule(),
+            &[ParseCondition::current(Token::Whitespace)],
+            &[
+                ParseCondition::current(Token::RightBlock),
+                ParseCondition::current(Token::ParagraphBreak),
+                ParseCondition::current(Token::LineBreak),
+            ],
+            Some(ParseWarningKind::BlockMalformedArguments),
+        )?;
+
+        let arguments = self.get_head_map(block_rule, in_head)?;
+
+        Ok((subname, arguments))
+    }
+
     pub fn get_head_value<F, T>(
         &mut self,
         block_rule: &BlockRule,

--- a/src/parse/rule/impls/block/rule.rs
+++ b/src/parse/rule/impls/block/rule.rs
@@ -147,8 +147,9 @@ where
     parser.get_optional_space()?;
 
     // Run the parse function until the end.
+    //
     // This is responsible for parsing any arguments,
     // and terminating the block (the ']]' token),
-    // then processing the body (if any) and close tag.
+    // then processing the body (if any) and tail block.
     (block.parse_fn)(log, parser, name, special, in_block)
 }

--- a/src/parse/rule/impls/block/rule.rs
+++ b/src/parse/rule/impls/block/rule.rs
@@ -129,7 +129,7 @@ where
     // Get block name
     parser.get_optional_space()?;
 
-    let (name, in_block) = parser.get_block_name()?;
+    let (name, in_head) = parser.get_block_name()?;
 
     // Get the block rule for this name
     let block = match get_block_rule_with_name(name) {
@@ -151,5 +151,5 @@ where
     // This is responsible for parsing any arguments,
     // and terminating the block (the ']]' token),
     // then processing the body (if any) and tail block.
-    (block.parse_fn)(log, parser, name, special, in_block)
+    (block.parse_fn)(log, parser, name, special, in_head)
 }

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -18,11 +18,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+//! Representation of syntax elements which wrap other elements.
+
 use crate::enums::HeadingLevel;
 use crate::tree::Element;
 use strum_macros::IntoStaticStr;
-
-/// Representation of syntax elements which wrap other elements.
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -114,7 +114,7 @@ pub enum Element<'t> {
     LineBreak,
 
     /// A collection of line breaks adjacent to each other.
-    LineBreaks { count: NonZeroU32 },
+    LineBreaks(NonZeroU32),
 
     /// A horizontal rule.
     HorizontalRule,

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::Container;
+use super::{Container, Module};
 use crate::enums::{AnchorTarget, LinkLabel};
 use std::borrow::Cow;
 use std::num::NonZeroU32;
@@ -30,6 +30,13 @@ pub enum Element<'t> {
     ///
     /// Examples would include italics, paragraphs, divs, etc.
     Container(Container<'t>),
+
+    /// A Wikidot module being invoked, along with its arguments.
+    ///
+    /// These modules require some kind of processing by backend software,
+    /// so are represented in module forum rather than as elements to be
+    /// directly rendered.
+    Module(Module<'t>),
 
     /// An element only containing text.
     ///
@@ -123,6 +130,7 @@ impl Element<'_> {
     pub fn name(&self) -> &'static str {
         match self {
             Element::Container(container) => container.ctype().name(),
+            Element::Module(module) => module.name(),
             Element::Text(_) => "Text",
             Element::Raw(_) => "Raw",
             Element::Email(_) => "Email",

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -20,9 +20,11 @@
 
 mod container;
 mod element;
+mod module;
 
 pub use self::container::*;
 pub use self::element::*;
+pub use self::module::*;
 
 use crate::parse::{ParseOutcome, ParseWarning};
 use std::borrow::Cow;

--- a/src/tree/module.rs
+++ b/src/tree/module.rs
@@ -1,0 +1,65 @@
+/*
+ * tree/module.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! Representation of Wikidot modules, along with their context.
+
+use std::borrow::Cow;
+use std::num::NonZeroU32;
+use strum_macros::IntoStaticStr;
+
+#[derive(Serialize, Deserialize, IntoStaticStr, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum Module<'t> {
+    /// Lists all the backlinks on the given page.
+    ///
+    /// If no page is listed, the backlinks are returned for the current page.
+    Backlinks { page: Option<Cow<'t, str>> },
+
+    /// Lists all categories on the site, along with the pages they contain.
+    Categories { include_hidden: bool },
+
+    /// Allows a user to join a site.
+    Join {
+        button_text: Option<Cow<'t, str>>,
+        id: Option<Cow<'t, str>>,
+        class: Option<Cow<'t, str>>,
+        style: Option<Cow<'t, str>>,
+    },
+
+    /// Lists the structure of pages as connected by parenthood.
+    ///
+    /// Shows the hierarchy of parent relationships present on the given page.
+    /// If no root page is listed, the tree returned is for the current page.
+    PageTree {
+        root: Option<Cow<'t, str>>,
+        show_root: bool,
+        depth: Option<NonZeroU32>,
+    },
+
+    /// A rating module, which can be used to vote on the page.
+    Rate,
+}
+
+impl Module<'_> {
+    #[inline]
+    pub fn name(&self) -> &'static str {
+        self.into()
+    }
+}

--- a/src/tree/module.rs
+++ b/src/tree/module.rs
@@ -33,6 +33,7 @@ pub enum Module<'t> {
     Backlinks { page: Option<Cow<'t, str>> },
 
     /// Lists all categories on the site, along with the pages they contain.
+    #[serde(rename_all = "kebab-case")]
     Categories { include_hidden: bool },
 
     /// Allows a user to join a site.
@@ -50,6 +51,7 @@ pub enum Module<'t> {
     ///
     /// Shows the hierarchy of parent relationships present on the given page.
     /// If no root page is listed, the tree returned is for the current page.
+    #[serde(rename_all = "kebab-case")]
     PageTree {
         root: Option<Cow<'t, str>>,
         show_root: bool,

--- a/src/tree/module.rs
+++ b/src/tree/module.rs
@@ -37,6 +37,7 @@ pub enum Module<'t> {
     Categories { include_hidden: bool },
 
     /// Allows a user to join a site.
+    #[serde(rename_all = "kebab-case")]
     Join {
         button_text: Option<Cow<'t, str>>,
         id: Option<Cow<'t, str>>,

--- a/src/tree/module.rs
+++ b/src/tree/module.rs
@@ -25,7 +25,7 @@ use std::num::NonZeroU32;
 use strum_macros::IntoStaticStr;
 
 #[derive(Serialize, Deserialize, IntoStaticStr, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", tag = "module", content = "data")]
 pub enum Module<'t> {
     /// Lists all the backlinks on the given page.
     ///

--- a/src/tree/module.rs
+++ b/src/tree/module.rs
@@ -43,6 +43,9 @@ pub enum Module<'t> {
         style: Option<Cow<'t, str>>,
     },
 
+    /// Meta-element for modules which perform no action.
+    Null,
+
     /// Lists the structure of pages as connected by parenthood.
     ///
     /// Shows the hierarchy of parent relationships present on the given page.

--- a/test/line-breaks-alias.json
+++ b/test/line-breaks-alias.json
@@ -13,9 +13,7 @@
                         },
                         {
                             "element": "line-breaks",
-                            "data": {
-                                "count": 9
-                            }
+                            "data": 9
                         },
                         {
                             "element": "text",

--- a/test/line-breaks-uppercase.json
+++ b/test/line-breaks-uppercase.json
@@ -13,9 +13,7 @@
                         },
                         {
                             "element": "line-breaks",
-                            "data": {
-                                "count": 12
-                            }
+                            "data": 12
                         },
                         {
                             "element": "text",

--- a/test/line-breaks.json
+++ b/test/line-breaks.json
@@ -13,9 +13,7 @@
                         },
                         {
                             "element": "line-breaks",
-                            "data": {
-                                "count": 3
-                            }
+                            "data": 3
                         },
                         {
                             "element": "text",

--- a/test/module-backlinks-page.json
+++ b/test/module-backlinks-page.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[module Backlinks page= \"scp-001\"]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "backlinks",
+                                "data": {
+                                    "page": "scp-001"
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-backlinks-uppercase.json
+++ b/test/module-backlinks-uppercase.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[ MODULE  BACKLINKS  ]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "backlinks",
+                                "data": {
+                                    "page": null
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-backlinks.json
+++ b/test/module-backlinks.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[module Backlinks]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "backlinks",
+                                "data": {
+                                    "page": null
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-categories-hidden.json
+++ b/test/module-categories-hidden.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[module Categories INCLUDEhidden= \"no\"]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "categories",
+                                "data": {
+                                    "include-hidden": false
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-categories-shown.json
+++ b/test/module-categories-shown.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[module Categories includeHidden = \"true\"]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "categories",
+                                "data": {
+                                    "include-hidden": true
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-categories-uppercase.json
+++ b/test/module-categories-uppercase.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[ MODULE CATEGORIES  ]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "categories",
+                                "data": {
+                                    "include-hidden": false
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-categories.json
+++ b/test/module-categories.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[module Categories]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "categories",
+                                "data": {
+                                    "include-hidden": false
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-css.json
+++ b/test/module-css.json
@@ -1,0 +1,12 @@
+{
+    "input": "[[module css]]\na { color: blue; }\n[[/module]]",
+    "tree": {
+        "elements": [
+        ],
+        "styles": [
+            "a { color: blue; }"
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-invalid.json
+++ b/test/module-invalid.json
@@ -1,0 +1,57 @@
+{
+    "input": "[[module NoSuchModuleWithThisName]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "[["
+                        },
+                        {
+                            "element": "text",
+                            "data": "module"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "NoSuchModuleWithThisName"
+                        },
+                        {
+                            "element": "text",
+                            "data": "]]"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+        {
+            "token": "input-end",
+            "rule": "block-module",
+            "span": [35, 35],
+            "kind": "no-such-module"
+        },
+        {
+            "token": "left-block",
+            "rule": "fallback",
+            "span": [0, 2],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "right-block",
+            "rule": "fallback",
+            "span": [33, 35],
+            "kind": "no-rules-match"
+        }
+    ]
+}

--- a/test/module-join-button.json
+++ b/test/module-join-button.json
@@ -1,0 +1,35 @@
+{
+    "input": "[[module Join button=\"Join our site!! ;-)\"]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "join",
+                                "data": {
+                                    "button-text": "Join our site!! ;-)",
+                                    "id": null,
+                                    "class": null,
+                                    "style": null
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-join-styling.json
+++ b/test/module-join-styling.json
@@ -1,0 +1,35 @@
+{
+    "input": "[[module Join id=\"join-btn\" CLASS =\"join-module\" stYLe= \"display: inline-block;\"]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "join",
+                                "data": {
+                                    "button-text": null,
+                                    "id": "join-btn",
+                                    "class": "join-module",
+                                    "style": "display: inline-block;"
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-join-uppercase.json
+++ b/test/module-join-uppercase.json
@@ -1,0 +1,35 @@
+{
+    "input": "[[ MODule  jOIN ]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "join",
+                                "data": {
+                                    "button-text": null,
+                                    "id": null,
+                                    "class": null,
+                                    "style": null
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-join.json
+++ b/test/module-join.json
@@ -1,0 +1,35 @@
+{
+    "input": "[[module Join]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "join",
+                                "data": {
+                                    "button-text": null,
+                                    "id": null,
+                                    "class": null,
+                                    "style": null
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-pagetree-fail-bool.json
+++ b/test/module-pagetree-fail-bool.json
@@ -1,0 +1,105 @@
+{
+    "input": "[[module PageTree root=\"scp-001\" showRoot=\"nope\" depth=\"2\"]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "[["
+                        },
+                        {
+                            "element": "text",
+                            "data": "module"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "PageTree"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "root"
+                        },
+                        {
+                            "element": "text",
+                            "data": "="
+                        },
+                        {
+                            "element": "text",
+                            "data": "\"scp-001\""
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "showRoot"
+                        },
+                        {
+                            "element": "text",
+                            "data": "="
+                        },
+                        {
+                            "element": "text",
+                            "data": "\"nope\""
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "depth"
+                        },
+                        {
+                            "element": "text",
+                            "data": "="
+                        },
+                        {
+                            "element": "text",
+                            "data": "\"2\""
+                        },
+                        {
+                            "element": "text",
+                            "data": "]]"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+        {
+            "token": "input-end",
+            "rule": "module-page-tree",
+            "span": [60, 60],
+            "kind": "block-malformed-arguments"
+        },
+        {
+            "token": "left-block",
+            "rule": "fallback",
+            "span": [0, 2],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "right-block",
+            "rule": "fallback",
+            "span": [58, 60],
+            "kind": "no-rules-match"
+        }
+    ]
+}

--- a/test/module-pagetree-fail-depth.json
+++ b/test/module-pagetree-fail-depth.json
@@ -1,0 +1,105 @@
+{
+    "input": "[[module PageTree root=\"scp-001\" showRoot=\"yes\" depth=\"0\"]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "[["
+                        },
+                        {
+                            "element": "text",
+                            "data": "module"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "PageTree"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "root"
+                        },
+                        {
+                            "element": "text",
+                            "data": "="
+                        },
+                        {
+                            "element": "text",
+                            "data": "\"scp-001\""
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "showRoot"
+                        },
+                        {
+                            "element": "text",
+                            "data": "="
+                        },
+                        {
+                            "element": "text",
+                            "data": "\"yes\""
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "depth"
+                        },
+                        {
+                            "element": "text",
+                            "data": "="
+                        },
+                        {
+                            "element": "text",
+                            "data": "\"0\""
+                        },
+                        {
+                            "element": "text",
+                            "data": "]]"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+        {
+            "token": "input-end",
+            "rule": "module-page-tree",
+            "span": [59, 59],
+            "kind": "block-malformed-arguments"
+        },
+        {
+            "token": "left-block",
+            "rule": "fallback",
+            "span": [0, 2],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "right-block",
+            "rule": "fallback",
+            "span": [57, 59],
+            "kind": "no-rules-match"
+        }
+    ]
+}

--- a/test/module-pagetree-options.json
+++ b/test/module-pagetree-options.json
@@ -1,0 +1,34 @@
+{
+    "input": "[[module PageTree root=\"scp-001\" showRoot = \"yes\"  depth =\"12\"]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "page-tree",
+                                "data": {
+                                    "root": "scp-001",
+                                    "show-root": true,
+                                    "depth": 12
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-pagetree-uppercase.json
+++ b/test/module-pagetree-uppercase.json
@@ -1,0 +1,34 @@
+{
+    "input": "[[ MODULE pageTREE ROOT =\"scp-series\" SHOWroot = \"yes\"  dePTH =\"3\"]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "page-tree",
+                                "data": {
+                                    "root": "scp-series",
+                                    "show-root": true,
+                                    "depth": 3
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-pagetree.json
+++ b/test/module-pagetree.json
@@ -1,0 +1,34 @@
+{
+    "input": "[[module PageTree]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "page-tree",
+                                "data": {
+                                    "root": null,
+                                    "show-root": false,
+                                    "depth": null
+                                }
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-rate-uppercase.json
+++ b/test/module-rate-uppercase.json
@@ -1,0 +1,29 @@
+{
+    "input": "[[ MODule rATe  ]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "rate"
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/module-rate.json
+++ b/test/module-rate.json
@@ -1,0 +1,29 @@
+{
+    "input": "[[module Rate]]\nApple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "module",
+                            "data": {
+                                "module": "rate"
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": "Apple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}


### PR DESCRIPTION
Adds `[[module XX]]`, which is like block except it has another layer of indirection in its module name. Each module can take its own form, and has its own parsing function as a result.

The module's evaluation is not computed here, but rather sent to the backend server, except in very trivial cases (e.g. `[[module CSS]]`).

The modules added in this initial version are:
* `Backlinks`
* `Categories`
* `CSS`
* `Join`
* `PageTree`
* `Rate`