### PR TITLE
Add [[span]]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,9 +488,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
+checksum = "90fa4cc29d25b0687b8570b0da86eac698dcb525110ad8b938fe6712baa711ec"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
+checksum = "31ebc390c6913de330e418add60e1a7e5af4cb5ec600d19111b339cafcdcc027"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -512,36 +512,36 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
+checksum = "089bd0baf024d3216916546338fffe4fc8dfffdd901e33c278abb091e0d52111"
 
 [[package]]
 name = "futures-io"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+checksum = "3868967e4e5ab86614e2176c99949eeef6cbcacaee737765f6ae693988273997"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
+checksum = "d4e0f6be0ec0357772fd58fb751958dd600bd0b3edfd429e77793e4282831360"
 
 [[package]]
 name = "futures-task"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
+checksum = "868090f28a925db6cb7462938c51d807546e298fb314088239f0e52fb4338b96"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
+checksum = "cad5e82786df758d407932aded1235e24d8e2eb438b6adafd37930c2462fb5d1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -633,13 +633,13 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "headers"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
+checksum = "62689dc57c7456e69712607ffcbd0aa1dfcccf9af73727e9b25bc1825375cac3"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "bitflags",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "headers-core",
  "http",
  "mime",
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -1591,7 +1591,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.1",
+ "rand 0.8.2",
  "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -60,6 +60,7 @@ mod css;
 mod div;
 mod lines;
 mod module;
+mod span;
 
 pub use self::code::BLOCK_CODE;
 pub use self::collapsible::BLOCK_COLLAPSIBLE;
@@ -67,3 +68,4 @@ pub use self::css::BLOCK_CSS;
 pub use self::div::BLOCK_DIV;
 pub use self::lines::BLOCK_LINES;
 pub use self::module::BLOCK_MODULE;
+pub use self::span::BLOCK_SPAN;

--- a/src/parse/rule/impls/block/blocks/span.rs
+++ b/src/parse/rule/impls/block/blocks/span.rs
@@ -59,13 +59,24 @@ fn parse_fn<'r, 't>(
     // Get body content, without paragraphs
     let (mut elements, exceptions) = parser.get_body_elements(&BLOCK_SPAN, false)?.into();
 
-    // Remove line breaks if "span_" is used.
     if strip_line_breaks {
-        elements.retain(|element| match element {
-            Element::LineBreak => false,
-            Element::LineBreaks(_) => false,
-            _ => true,
-        });
+        // Remove leading line breaks
+        while let Some(element) = elements.first() {
+            if !matches!(element, Element::LineBreak | Element::LineBreaks(_)) {
+                break;
+            }
+
+            elements.remove(0);
+        }
+
+        // Remove trailing line breaks
+        while let Some(element) = elements.last() {
+            if !matches!(element, Element::LineBreak | Element::LineBreaks(_)) {
+                break;
+            }
+
+            elements.pop();
+        }
     }
 
     let element = Element::Span {

--- a/src/parse/rule/impls/block/blocks/span.rs
+++ b/src/parse/rule/impls/block/blocks/span.rs
@@ -1,0 +1,79 @@
+/*
+ * parse/rule/impls/block/blocks/span.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Ammon Smith
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+
+pub const BLOCK_SPAN: BlockRule = BlockRule {
+    name: "block-span",
+    accepts_names: &["span", "span_"],
+    accepts_special: false,
+    newline_separator: false,
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    special: bool,
+    in_head: bool,
+) -> ParseResult<'r, 't, Element<'t>> {
+    debug!(
+        log,
+        "Parsing span block";
+        "in-head" => in_head,
+        "name" => name,
+    );
+
+    assert_eq!(special, false, "Span doesn't allow special variant");
+    assert_block_name(&BLOCK_SPAN, name);
+
+    let mut arguments = parser.get_head_map(&BLOCK_SPAN, in_head)?;
+
+    // "span" means we wrap interpret as-is
+    // "span_" means we strip out any newlines or paragraph breaks
+    let strip_line_breaks = name.ends_with('_');
+
+    // Get styling arguments
+    let id = arguments.get("id");
+    let class = arguments.get("class");
+    let style = arguments.get("style");
+
+    // Get body content, without paragraphs
+    let (mut elements, exceptions) = parser.get_body_elements(&BLOCK_SPAN, false)?.into();
+
+    // Remove line breaks if "span_" is used.
+    if strip_line_breaks {
+        elements.retain(|element| match element {
+            Element::LineBreak => false,
+            Element::LineBreaks(_) => false,
+            _ => true,
+        });
+    }
+
+    let element = Element::Span {
+        elements,
+        id,
+        class,
+        style,
+    };
+
+    ok!(element, exceptions)
+}

--- a/src/parse/rule/impls/block/mapping.rs
+++ b/src/parse/rule/impls/block/mapping.rs
@@ -22,13 +22,14 @@ use super::{blocks::*, BlockRule};
 use std::collections::HashMap;
 use unicase::UniCase;
 
-pub const BLOCK_RULES: [BlockRule; 6] = [
+pub const BLOCK_RULES: [BlockRule; 7] = [
     BLOCK_CODE,
     BLOCK_COLLAPSIBLE,
     BLOCK_CSS,
     BLOCK_DIV,
     BLOCK_LINES,
     BLOCK_MODULE,
+    BLOCK_SPAN,
 ];
 
 pub type BlockRuleMap = HashMap<UniCase<&'static str>, &'static BlockRule>;

--- a/src/parse/rule/impls/line_break.rs
+++ b/src/parse/rule/impls/line_break.rs
@@ -22,14 +22,42 @@ use super::prelude::*;
 
 pub const RULE_LINE_BREAK: Rule = Rule {
     name: "line-break",
-    try_consume_fn,
+    try_consume_fn: line_break,
 };
 
-fn try_consume_fn<'p, 'r, 't>(
+pub const RULE_LINE_BREAK_PARAGRAPH: Rule = Rule {
+    name: "line-break-paragraph",
+    try_consume_fn: line_break_paragraph,
+};
+
+fn line_break<'p, 'r, 't>(
     log: &slog::Logger,
     _parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Element<'t>> {
-    debug!(log, "Consuming token as line break");
+    debug!(log, "Consuming newline token as line break");
+
+    ok!(Element::LineBreak)
+}
+
+fn line_break_paragraph<'p, 'r, 't>(
+    log: &slog::Logger,
+    _parser: &'p mut Parser<'r, 't>,
+) -> ParseResult<'r, 't, Element<'t>> {
+    debug!(log, "Consuming paragraph break as line break");
+
+    // This rule is kind of special. It's the same as RULE_LINE_BREAK,
+    // except it accepts a *ParagraphBreak* instead, which is normally supposed to split
+    // paragraphs.
+    //
+    // So what's going on?
+    //
+    // In "normal" contexts, you extract paragraphs (see gather_paragraphs()), so any
+    // Token::ParagraphBreak tokens are used to affected the ParagraphStack and create
+    // a new paragraph container.
+    //
+    // However other contexts do not allow new paragraphs to form, such as [[span]].
+    // In these cases, if we encounter two or more newlines, we must pretend it's simply
+    // one regular newline, or a line break.
 
     ok!(Element::LineBreak)
 }

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -66,7 +66,7 @@ pub use self::email::RULE_EMAIL;
 pub use self::fallback::RULE_FALLBACK;
 pub use self::horizontal_rule::RULE_HORIZONTAL_RULE;
 pub use self::italics::RULE_ITALICS;
-pub use self::line_break::RULE_LINE_BREAK;
+pub use self::line_break::{RULE_LINE_BREAK, RULE_LINE_BREAK_PARAGRAPH};
 pub use self::link_anchor::RULE_LINK_ANCHOR;
 pub use self::link_single::{RULE_LINK_SINGLE, RULE_LINK_SINGLE_NEW_TAB};
 pub use self::link_triple::{RULE_LINK_TRIPLE, RULE_LINK_TRIPLE_NEW_TAB};

--- a/src/parse/rule/mapping.rs
+++ b/src/parse/rule/mapping.rs
@@ -54,7 +54,7 @@ lazy_static! {
             Token::Quote => vec![RULE_TODO, RULE_TEXT], // TODO
             Token::Heading => vec![RULE_TODO, RULE_TEXT], // TODO
             Token::LineBreak => vec![RULE_BLOCK_SKIP, RULE_LINE_BREAK],
-            Token::ParagraphBreak => vec![RULE_TODO], // TODO
+            Token::ParagraphBreak => vec![RULE_LINE_BREAK_PARAGRAPH],
             Token::Whitespace => vec![RULE_TEXT],
 
             // Formatting

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -94,6 +94,14 @@ pub enum Element<'t> {
         elements: Vec<Element<'t>>,
     },
 
+    /// Element containing an HTML span.
+    Span {
+        elements: Vec<Element<'t>>,
+        id: Option<Cow<'t, str>>,
+        class: Option<Cow<'t, str>>,
+        style: Option<Cow<'t, str>>,
+    },
+
     /// Element containing an HTML div.
     Div {
         elements: Vec<Element<'t>>,
@@ -137,6 +145,7 @@ impl Element<'_> {
             Element::Link { .. } => "Link",
             Element::Collapsible { .. } => "Collapsible",
             Element::Color { .. } => "Color",
+            Element::Span { .. } => "Span",
             Element::Div { .. } => "Div",
             Element::Code { .. } => "Code",
             Element::LineBreak => "LineBreak",

--- a/test/div.json
+++ b/test/div.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[div_]]\nApple\n[[/div]]",
+    "input": "[[div]]\nApple\n[[/div]]",
     "tree": {
         "elements": [
             {
@@ -15,8 +15,16 @@
                                 "style": null,
                                 "elements": [
                                     {
-                                        "element": "text",
-                                        "data": "Apple"
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Apple"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/test/span-empty.json
+++ b/test/span-empty.json
@@ -1,0 +1,29 @@
+{
+    "input": "[[span]][[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span-newlines-2.json
+++ b/test/span-newlines-2.json
@@ -1,0 +1,40 @@
+{
+    "input": "[[span]]Banana\nCherry[[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Banana"
+                                    },
+                                    {
+                                        "element": "line-break"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "Cherry"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span-newlines.json
+++ b/test/span-newlines.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[span]]\nBanana\nCherry\n[[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                    {
+                                        "element": "line-break"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "Banana"
+                                    },
+                                    {
+                                        "element": "line-break"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "Cherry"
+                                    },
+                                    {
+                                        "element": "line-break"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span-style.json
+++ b/test/span-style.json
@@ -1,0 +1,33 @@
+{
+    "input": "[[span id=\"banana\" class=\"fruit\" style=\"color: yellow;\"]]Banana[[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": "banana",
+                                "class": "fruit",
+                                "style": "color: yellow;",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Banana"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span-uppercase.json
+++ b/test/span-uppercase.json
@@ -1,0 +1,33 @@
+{
+    "input": "[[SPAN ID =  \"apple\" clASS =\"fruit\" stylE=\"color: red;\"      ]]Apple[[/ SPAN_  ]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": "apple",
+                                "class": "fruit",
+                                "style": "color: red;",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Apple"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span.json
+++ b/test/span.json
@@ -1,0 +1,33 @@
+{
+    "input": "[[span]]Banana[[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Banana"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span2-empty.json
+++ b/test/span2-empty.json
@@ -1,0 +1,29 @@
+{
+    "input": "[[span_]][[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span2-newlines-2.json
+++ b/test/span2-newlines-2.json
@@ -1,0 +1,40 @@
+{
+    "input": "[[span]]Banana\nCherry[[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Banana"
+                                    },
+                                    {
+                                        "element": "line-break"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "Cherry"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span2-newlines.json
+++ b/test/span2-newlines.json
@@ -1,0 +1,40 @@
+{
+    "input": "[[span_]]\nBanana\nCherry\n[[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Banana"
+                                    },
+                                    {
+                                        "element": "line-break"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "Cherry"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span2-style.json
+++ b/test/span2-style.json
@@ -1,0 +1,33 @@
+{
+    "input": "[[span_ id=\"banana\" class=\"fruit\" style=\"color: yellow;\"]]Banana[[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": "banana",
+                                "class": "fruit",
+                                "style": "color: yellow;",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Banana"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span2-uppercase.json
+++ b/test/span2-uppercase.json
@@ -1,0 +1,33 @@
+{
+    "input": "[[SPAN_ ID =  \"apple\" clASS =\"fruit\" stylE=\"color: red;\"      ]]Apple[[/ SPAN ]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": "apple",
+                                "class": "fruit",
+                                "style": "color: red;",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Apple"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/test/span2.json
+++ b/test/span2.json
@@ -1,0 +1,33 @@
+{
+    "input": "[[span_]]Banana[[/span]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "span",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Banana"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}


### PR DESCRIPTION
First non-newline-required block, pretty easily to implement.

Learned some [strange things](http://scptestwiki.wikidot.com/span-tests) about how Wikidot does `[[span_]]`, so this implementation just does a simpler "strip newlines from the start and end of the span internals".