### PR TITLE
Add style container to wrap HTML elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "lazy_static",
  "pest",
  "pest_derive",
+ "ref-map",
  "regex",
  "serde",
  "serde_json",
@@ -1265,6 +1266,12 @@ dependencies = [
  "redox_syscall 0.1.57",
  "rust-argon2",
 ]
+
+[[package]]
+name = "ref-map"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703281d31f29412a41ce63af76576f2f9db5628731414ca4c06b4c454b93ea5d"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ enum-map = "0.6"
 lazy_static = "1"
 pest = "2"
 pest_derive = "2"
+ref-map = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -95,6 +95,18 @@ impl HeadingLevel {
             HeadingLevel::Six => 6,
         }
     }
+
+    #[inline]
+    pub fn html_tag(self) -> &'static str {
+        match self {
+            HeadingLevel::One => "h1",
+            HeadingLevel::Two => "h2",
+            HeadingLevel::Three => "h3",
+            HeadingLevel::Four => "h4",
+            HeadingLevel::Five => "h5",
+            HeadingLevel::Six => "h6",
+        }
+    }
 }
 
 impl TryFrom<usize> for HeadingLevel {
@@ -112,6 +124,7 @@ impl TryFrom<usize> for HeadingLevel {
         }
     }
 }
+
 impl TryFrom<u8> for HeadingLevel {
     type Error = ();
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -50,6 +50,26 @@ impl AnchorTarget {
     pub fn name(self) -> &'static str {
         self.into()
     }
+
+    #[inline]
+    pub fn html_attr(self) -> &'static str {
+        match self {
+            AnchorTarget::NewTab => "_blank",
+            AnchorTarget::Parent => "_parent",
+            AnchorTarget::Top => "_top",
+            AnchorTarget::Same => "_same",
+        }
+    }
+
+    #[inline]
+    pub fn html_attr_needed(self) -> Option<&'static str> {
+        match self {
+            AnchorTarget::NewTab => Some("_blank"),
+            AnchorTarget::Parent => Some("_parent"),
+            AnchorTarget::Top => Some("_top"),
+            AnchorTarget::Same => None,
+        }
+    }
 }
 
 impl<'a> TryFrom<&'a str> for AnchorTarget {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ extern crate pest;
 
 #[macro_use]
 extern crate pest_derive;
+extern crate ref_map;
 extern crate regex;
 
 #[macro_use]

--- a/src/parse/lexer.pest
+++ b/src/parse/lexer.pest
@@ -78,8 +78,8 @@ token = _{
     right_bracket |
 
     // Formatting
-    bold |
-    italics |
+    strong |
+    emphasis |
     underline |
     superscript |
     subscript |
@@ -171,8 +171,8 @@ heading = { "+"{1,6} }
 
 // Formatting {{{
 
-bold = { "**" }
-italics = { "//" }
+strong = { "**" }
+emphasis = { "//" }
 underline = { "__" }
 superscript = { "^^" }
 subscript = { ",," }

--- a/src/parse/rule/impls/block/blocks/del.rs
+++ b/src/parse/rule/impls/block/blocks/del.rs
@@ -56,12 +56,13 @@ fn parse_fn<'r, 't>(
     let (elements, exceptions) = parser.get_body_elements(&BLOCK_DEL, false)?.into();
 
     // Build and return element
-    let element = Element::Deletion {
+    let element = Element::StyledContainer(StyledContainer::new(
+        StyledContainerType::Deletion,
         elements,
         id,
         class,
         style,
-    };
+    ));
 
     ok!(element, exceptions)
 }

--- a/src/parse/rule/impls/block/blocks/div.rs
+++ b/src/parse/rule/impls/block/blocks/div.rs
@@ -62,12 +62,13 @@ fn parse_fn<'r, 't>(
         .into();
 
     // Build element and return
-    let element = Element::Div {
+    let element = Element::StyledContainer(StyledContainer::new(
+        StyledContainerType::Div,
         elements,
         id,
         class,
         style,
-    };
+    ));
 
     ok!(element, exceptions)
 }

--- a/src/parse/rule/impls/block/blocks/ins.rs
+++ b/src/parse/rule/impls/block/blocks/ins.rs
@@ -56,12 +56,13 @@ fn parse_fn<'r, 't>(
     let (elements, exceptions) = parser.get_body_elements(&BLOCK_INS, false)?.into();
 
     // Build and return element
-    let element = Element::Insertion {
+    let element = Element::StyledContainer(StyledContainer::new(
+        StyledContainerType::Insertion,
         elements,
         id,
         class,
         style,
-    };
+    ));
 
     ok!(element, exceptions)
 }

--- a/src/parse/rule/impls/block/blocks/mark.rs
+++ b/src/parse/rule/impls/block/blocks/mark.rs
@@ -56,12 +56,13 @@ fn parse_fn<'r, 't>(
     let (elements, exceptions) = parser.get_body_elements(&BLOCK_MARK, false)?.into();
 
     // Build and return element
-    let element = Element::Mark {
+    let element = Element::StyledContainer(StyledContainer::new(
+        StyledContainerType::Mark,
         elements,
         id,
         class,
         style,
-    };
+    ));
 
     ok!(element, exceptions)
 }

--- a/src/parse/rule/impls/block/blocks/mod.rs
+++ b/src/parse/rule/impls/block/blocks/mod.rs
@@ -25,7 +25,9 @@ mod prelude {
     pub use crate::parse::parser::Parser;
     pub use crate::parse::prelude::*;
     pub use crate::parse::{ParseWarning, Token};
-    pub use crate::tree::Element;
+    pub use crate::tree::{
+        Container, ContainerType, Element, StyledContainer, StyledContainerType,
+    };
 
     #[cfg(debug)]
     pub fn assert_generic_name(

--- a/src/parse/rule/impls/block/blocks/span.rs
+++ b/src/parse/rule/impls/block/blocks/span.rs
@@ -79,12 +79,13 @@ fn parse_fn<'r, 't>(
         }
     }
 
-    let element = Element::Span {
+    let element = Element::StyledContainer(StyledContainer::new(
+        StyledContainerType::Span,
         elements,
         id,
         class,
         style,
-    };
+    ));
 
     ok!(element, exceptions)
 }

--- a/src/parse/rule/impls/emphasis.rs
+++ b/src/parse/rule/impls/emphasis.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/italics.rs
+ * parse/rule/impls/emphasis.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Ammon Smith
@@ -20,8 +20,8 @@
 
 use super::prelude::*;
 
-pub const RULE_ITALICS: Rule = Rule {
-    name: "italics",
+pub const RULE_EMPHASIS: Rule = Rule {
+    name: "emphasis",
     try_consume_fn,
 };
 
@@ -29,20 +29,20 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &slog::Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Element<'t>> {
-    debug!(log, "Trying to create italics container");
+    debug!(log, "Trying to create emphasis (italics) container");
 
-    check_step(parser, Token::Italics)?;
+    check_step(parser, Token::Emphasis)?;
 
     collect_container(
         log,
         parser,
-        RULE_ITALICS,
-        ContainerType::Italics,
-        &[ParseCondition::current(Token::Italics)],
+        RULE_EMPHASIS,
+        ContainerType::Emphasis,
+        &[ParseCondition::current(Token::Emphasis)],
         &[
             ParseCondition::current(Token::ParagraphBreak),
-            ParseCondition::token_pair(Token::Italics, Token::Whitespace),
-            ParseCondition::token_pair(Token::Whitespace, Token::Italics),
+            ParseCondition::token_pair(Token::Emphasis, Token::Whitespace),
+            ParseCondition::token_pair(Token::Whitespace, Token::Emphasis),
         ],
         None,
     )

--- a/src/parse/rule/impls/mod.rs
+++ b/src/parse/rule/impls/mod.rs
@@ -33,14 +33,13 @@ mod prelude {
 }
 
 mod block;
-mod bold;
 mod color;
 mod comment;
 mod dash;
 mod email;
+mod emphasis;
 mod fallback;
 mod horizontal_rule;
-mod italics;
 mod line_break;
 mod link_anchor;
 mod link_single;
@@ -50,6 +49,7 @@ mod null;
 mod page;
 mod raw;
 mod strikethrough;
+mod strong;
 mod subscript;
 mod superscript;
 mod text;
@@ -58,14 +58,13 @@ mod underline;
 mod url;
 
 pub use self::block::{RULE_BLOCK, RULE_BLOCK_SKIP, RULE_BLOCK_SPECIAL};
-pub use self::bold::RULE_BOLD;
 pub use self::color::RULE_COLOR;
 pub use self::comment::RULE_COMMENT;
 pub use self::dash::RULE_DASH;
 pub use self::email::RULE_EMAIL;
+pub use self::emphasis::RULE_EMPHASIS;
 pub use self::fallback::RULE_FALLBACK;
 pub use self::horizontal_rule::RULE_HORIZONTAL_RULE;
-pub use self::italics::RULE_ITALICS;
 pub use self::line_break::{RULE_LINE_BREAK, RULE_LINE_BREAK_PARAGRAPH};
 pub use self::link_anchor::RULE_LINK_ANCHOR;
 pub use self::link_single::{RULE_LINK_SINGLE, RULE_LINK_SINGLE_NEW_TAB};
@@ -75,6 +74,7 @@ pub use self::null::RULE_NULL;
 pub use self::page::RULE_PAGE;
 pub use self::raw::RULE_RAW;
 pub use self::strikethrough::RULE_STRIKETHROUGH;
+pub use self::strong::RULE_STRONG;
 pub use self::subscript::RULE_SUBSCRIPT;
 pub use self::superscript::RULE_SUPERSCRIPT;
 pub use self::text::RULE_TEXT;

--- a/src/parse/rule/impls/strong.rs
+++ b/src/parse/rule/impls/strong.rs
@@ -1,5 +1,5 @@
 /*
- * parse/rule/impls/bold.rs
+ * parse/rule/impls/strong.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Ammon Smith
@@ -20,8 +20,8 @@
 
 use super::prelude::*;
 
-pub const RULE_BOLD: Rule = Rule {
-    name: "bold",
+pub const RULE_STRONG: Rule = Rule {
+    name: "strong",
     try_consume_fn,
 };
 
@@ -29,20 +29,20 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &slog::Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Element<'t>> {
-    debug!(log, "Trying to create bold container");
+    debug!(log, "Trying to create strong (bold) container");
 
-    check_step(parser, Token::Bold)?;
+    check_step(parser, Token::Strong)?;
 
     collect_container(
         log,
         parser,
-        RULE_BOLD,
-        ContainerType::Bold,
-        &[ParseCondition::current(Token::Bold)],
+        RULE_STRONG,
+        ContainerType::Strong,
+        &[ParseCondition::current(Token::Strong)],
         &[
             ParseCondition::current(Token::ParagraphBreak),
-            ParseCondition::token_pair(Token::Bold, Token::Whitespace),
-            ParseCondition::token_pair(Token::Whitespace, Token::Bold),
+            ParseCondition::token_pair(Token::Strong, Token::Whitespace),
+            ParseCondition::token_pair(Token::Whitespace, Token::Strong),
         ],
         None,
     )

--- a/src/parse/rule/mapping.rs
+++ b/src/parse/rule/mapping.rs
@@ -58,8 +58,8 @@ lazy_static! {
             Token::Whitespace => vec![RULE_TEXT],
 
             // Formatting
-            Token::Bold => vec![RULE_BOLD],
-            Token::Italics => vec![RULE_ITALICS],
+            Token::Strong => vec![RULE_STRONG],
+            Token::Emphasis => vec![RULE_EMPHASIS],
             Token::Underline => vec![RULE_UNDERLINE],
             Token::Superscript => vec![RULE_SUPERSCRIPT],
             Token::Subscript => vec![RULE_SUBSCRIPT],

--- a/src/parse/token/mod.rs
+++ b/src/parse/token/mod.rs
@@ -76,8 +76,8 @@ pub enum Token {
     //
     // Formatting
     //
-    Bold,
-    Italics,
+    Strong,
+    Emphasis,
     Underline,
     Superscript,
     Subscript,
@@ -218,8 +218,8 @@ impl Token {
             Rule::space => Token::Whitespace,
 
             // Formatting
-            Rule::bold => Token::Bold,
-            Rule::italics => Token::Italics,
+            Rule::strong => Token::Strong,
+            Rule::emphasis => Token::Emphasis,
             Rule::underline => Token::Underline,
             Rule::superscript => Token::Superscript,
             Rule::subscript => Token::Subscript,

--- a/src/render/debug.rs
+++ b/src/render/debug.rs
@@ -47,7 +47,7 @@ fn debug() {
         ),
         Container(
             Container {
-                ctype: Bold,
+                ctype: Strong,
                 elements: [
                     Text(
                         "banana",
@@ -65,7 +65,7 @@ fn debug() {
     let elements = vec![
         text!("apple"),
         text!(" "),
-        Element::Container(Container::new(ContainerType::Bold, vec![text!("banana")])),
+        Element::Container(Container::new(ContainerType::Strong, vec![text!("banana")])),
     ];
     let warnings = vec![];
     let styles = vec![cow!("span.hidden-text { display: none; }")];

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -73,7 +73,7 @@ fn json() {
     {
       "element": "container",
       "data": {
-        "type": "bold",
+        "type": "strong",
         "elements": [
           {
             "element": "text",
@@ -88,13 +88,13 @@ fn json() {
   ]
 }"#;
 
-    const COMPACT_OUTPUT: &str = "{\"elements\":[{\"element\":\"text\",\"data\":\"apple\"},{\"element\":\"text\",\"data\":\" \"},{\"element\":\"container\",\"data\":{\"type\":\"bold\",\"elements\":[{\"element\":\"text\",\"data\":\"banana\"}]}}],\"styles\":[\"span.hidden-text { display: none; }\"]}";
+    const COMPACT_OUTPUT: &str = "{\"elements\":[{\"element\":\"text\",\"data\":\"apple\"},{\"element\":\"text\",\"data\":\" \"},{\"element\":\"container\",\"data\":{\"type\":\"strong\",\"elements\":[{\"element\":\"text\",\"data\":\"banana\"}]}}],\"styles\":[\"span.hidden-text { display: none; }\"]}";
 
     // Syntax tree construction
     let elements = vec![
         text!("apple"),
         text!(" "),
-        Element::Container(Container::new(ContainerType::Bold, vec![text!("banana")])),
+        Element::Container(Container::new(ContainerType::Strong, vec![text!("banana")])),
     ];
     let warnings = vec![];
     let styles = vec![cow!("span.hidden-text { display: none; }")];

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -80,7 +80,13 @@ impl<'t> StyledContainer<'t> {
         class: Option<Cow<'t, str>>,
         style: Option<Cow<'t, str>>,
     ) -> Self {
-        StyledContainer { ctype, elements, id, class, style }
+        StyledContainer {
+            ctype,
+            elements,
+            id,
+            class,
+            style,
+        }
     }
 
     #[inline]

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -130,8 +130,8 @@ impl<'t> From<StyledContainer<'t>> for Vec<Element<'t>> {
 #[serde(rename_all = "kebab-case")]
 pub enum ContainerType {
     Paragraph,
-    Bold,
-    Italics,
+    Strong,
+    Emphasis,
     Underline,
     Superscript,
     Subscript,
@@ -150,8 +150,8 @@ impl ContainerType {
     pub fn html_tag(self) -> &'static str {
         match self {
             ContainerType::Paragraph => "p",
-            ContainerType::Bold => "strong",
-            ContainerType::Italics => "italics",
+            ContainerType::Strong => "strong",
+            ContainerType::Emphasis => "italics",
             ContainerType::Underline => "u",
             ContainerType::Superscript => "sup",
             ContainerType::Subscript => "sub",

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -60,40 +60,6 @@ impl<'t> From<Container<'t>> for Vec<Element<'t>> {
     }
 }
 
-#[derive(
-    Serialize, Deserialize, IntoStaticStr, Debug, Copy, Clone, Hash, PartialEq, Eq,
-)]
-#[serde(rename_all = "kebab-case")]
-pub enum ContainerType {
-    Paragraph,
-    Bold,
-    Italics,
-    Underline,
-    Superscript,
-    Subscript,
-    Strikethrough,
-    Monospace,
-    Header(HeadingLevel),
-}
-
-impl ContainerType {
-    #[inline]
-    pub fn name(self) -> &'static str {
-        self.into()
-    }
-}
-
-impl slog::Value for ContainerType {
-    fn serialize(
-        &self,
-        _: &slog::Record,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_str(key, self.name())
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct StyledContainer<'t> {
@@ -152,6 +118,39 @@ impl<'t> From<StyledContainer<'t>> for Vec<Element<'t>> {
     }
 }
 
+#[derive(
+    Serialize, Deserialize, IntoStaticStr, Debug, Copy, Clone, Hash, PartialEq, Eq,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContainerType {
+    Paragraph,
+    Bold,
+    Italics,
+    Underline,
+    Superscript,
+    Subscript,
+    Strikethrough,
+    Monospace,
+    Header(HeadingLevel),
+}
+
+impl ContainerType {
+    #[inline]
+    pub fn name(self) -> &'static str {
+        self.into()
+    }
+}
+
+impl slog::Value for ContainerType {
+    fn serialize(
+        &self,
+        _: &slog::Record,
+        key: slog::Key,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        serializer.emit_str(key, self.name())
+    }
+}
 
 #[derive(
     Serialize, Deserialize, IntoStaticStr, Debug, Copy, Clone, Hash, PartialEq, Eq,

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -129,31 +129,14 @@ impl<'t> From<StyledContainer<'t>> for Vec<Element<'t>> {
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum ContainerType {
-    /// Paragraphs. HTML tag `<p>`.
     Paragraph,
-
-    /// Bolded text. HTML tag `<strong>`.
     Bold,
-
-    /// Italicized text. HTML tag `<em>`.
     Italics,
-
-    /// Underlined text. HTML tag `<u>`
     Underline,
-
-    /// Superscript text. HTML tag `<sup>`.
     Superscript,
-
-    /// Subscript text. HTML tag `<sub>`.
     Subscript,
-
-    /// Strikethrough. HTML tag `<s>`.
     Strikethrough,
-
-    /// Monospace or teletype text. HTML tag `<tt>`.
     Monospace,
-
-    /// Header. HTML tags `<h1>` through `<h6>`.
     Header(HeadingLevel),
 }
 
@@ -161,6 +144,21 @@ impl ContainerType {
     #[inline]
     pub fn name(self) -> &'static str {
         self.into()
+    }
+
+    #[inline]
+    pub fn html_tag(self) -> &'static str {
+        match self {
+            ContainerType::Paragraph => "p",
+            ContainerType::Bold => "strong",
+            ContainerType::Italics => "italics",
+            ContainerType::Underline => "u",
+            ContainerType::Superscript => "sup",
+            ContainerType::Subscript => "sub",
+            ContainerType::Strikethrough => "s",
+            ContainerType::Monospace => "tt",
+            ContainerType::Header(level) => level.html_tag(),
+        }
     }
 }
 
@@ -180,19 +178,10 @@ impl slog::Value for ContainerType {
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum StyledContainerType {
-    /// Span of text. HTML tag `<span>`.
     Span,
-
-    /// Division of text. HTML tag `<div>`.
     Div,
-
-    /// Marked or highlighted text. HTML tag `<mark>`.
     Mark,
-
-    /// Inserted text. HTML tag `<ins>`.
     Insertion,
-
-    /// Deleted text. HTML tag `<del>`.
     Deletion,
 }
 
@@ -200,6 +189,17 @@ impl StyledContainerType {
     #[inline]
     pub fn name(self) -> &'static str {
         self.into()
+    }
+
+    #[inline]
+    pub fn html_tag(self) -> &'static str {
+        match self {
+            StyledContainerType::Span => "span",
+            StyledContainerType::Div => "div",
+            StyledContainerType::Mark => "mark",
+            StyledContainerType::Insertion => "ins",
+            StyledContainerType::Deletion => "del",
+        }
     }
 }
 

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -123,14 +123,31 @@ impl<'t> From<StyledContainer<'t>> for Vec<Element<'t>> {
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum ContainerType {
+    /// Paragraphs. HTML tag `<p>`.
     Paragraph,
+
+    /// Bolded text. HTML tag `<strong>`.
     Bold,
+
+    /// Italicized text. HTML tag `<em>`.
     Italics,
+
+    /// Underlined text. HTML tag `<u>`
     Underline,
+
+    /// Superscript text. HTML tag `<sup>`.
     Superscript,
+
+    /// Subscript text. HTML tag `<sub>`.
     Subscript,
+
+    /// Strikethrough. HTML tag `<s>`.
     Strikethrough,
+
+    /// Monospace or teletype text. HTML tag `<tt>`.
     Monospace,
+
+    /// Header. HTML tags `<h1>` through `<h6>`.
     Header(HeadingLevel),
 }
 

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -174,6 +174,20 @@ impl slog::Value for ContainerType {
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum StyledContainerType {
+    /// Span of text. HTML tag `<span>`.
+    Span,
+
+    /// Division of text. HTML tag `<div>`.
+    Div,
+
+    /// Marked or highlighted text. HTML tag `<mark>`.
+    Mark,
+
+    /// Inserted text. HTML tag `<ins>`.
+    Insertion,
+
+    /// Deleted text. HTML tag `<del>`.
+    Deletion,
 }
 
 impl StyledContainerType {

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-//! Representation of syntax elements which wrap other elements.
+//! Representation of generic syntax elements which wrap other elements.
 
 use crate::enums::HeadingLevel;
 use crate::tree::Element;
@@ -35,11 +35,7 @@ pub struct Container<'t> {
 
 impl<'t> Container<'t> {
     #[inline]
-    pub fn new(ctype: ContainerType, mut elements: Vec<Element<'t>>) -> Self {
-        // Prune out null elements
-        elements.retain(|element| element != &Element::Null);
-
-        // Build object
+    pub fn new(ctype: ContainerType, elements: Vec<Element<'t>>) -> Self {
         Container { ctype, elements }
     }
 

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::{Container, StyledContainer, Module};
+use super::{Container, Module, StyledContainer};
 use crate::enums::{AnchorTarget, LinkLabel};
 use std::borrow::Cow;
 use std::num::NonZeroU32;

--- a/src/tree/element.rs
+++ b/src/tree/element.rs
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::{Container, Module};
+use super::{Container, StyledContainer, Module};
 use crate::enums::{AnchorTarget, LinkLabel};
 use std::borrow::Cow;
 use std::num::NonZeroU32;
@@ -28,8 +28,13 @@ use std::num::NonZeroU32;
 pub enum Element<'t> {
     /// Generic element that contains other elements within it.
     ///
-    /// Examples would include italics, paragraphs, divs, etc.
+    /// Examples would include italics, paragraphs, etc.
     Container(Container<'t>),
+
+    /// Generic element that contains other elements, with added styling.
+    ///
+    /// Examples would include divs, spans, etc.
+    StyledContainer(StyledContainer<'t>),
 
     /// A Wikidot module being invoked, along with its arguments.
     ///
@@ -94,49 +99,6 @@ pub enum Element<'t> {
         elements: Vec<Element<'t>>,
     },
 
-    /// Element containing an HTML span.
-    Span {
-        elements: Vec<Element<'t>>,
-        id: Option<Cow<'t, str>>,
-        class: Option<Cow<'t, str>>,
-        style: Option<Cow<'t, str>>,
-    },
-
-    /// Element containing an HTML div.
-    Div {
-        elements: Vec<Element<'t>>,
-        id: Option<Cow<'t, str>>,
-        class: Option<Cow<'t, str>>,
-        style: Option<Cow<'t, str>>,
-    },
-
-    /// Element representing marked or highlighted text.
-    /// HTML tag `<mark>`
-    Mark {
-        elements: Vec<Element<'t>>,
-        id: Option<Cow<'t, str>>,
-        class: Option<Cow<'t, str>>,
-        style: Option<Cow<'t, str>>,
-    },
-
-    /// Element representing added text.
-    /// HTML tag `<ins>`
-    Insertion {
-        elements: Vec<Element<'t>>,
-        id: Option<Cow<'t, str>>,
-        class: Option<Cow<'t, str>>,
-        style: Option<Cow<'t, str>>,
-    },
-
-    /// Element representing removed text.
-    /// HTML tag `<del>`
-    Deletion {
-        elements: Vec<Element<'t>>,
-        id: Option<Cow<'t, str>>,
-        class: Option<Cow<'t, str>>,
-        style: Option<Cow<'t, str>>,
-    },
-
     /// Element containing a code block
     Code {
         contents: Cow<'t, str>,
@@ -165,6 +127,7 @@ impl Element<'_> {
     pub fn name(&self) -> &'static str {
         match self {
             Element::Container(container) => container.ctype().name(),
+            Element::StyledContainer(container) => container.ctype().name(),
             Element::Module(module) => module.name(),
             Element::Text(_) => "Text",
             Element::Raw(_) => "Raw",
@@ -172,11 +135,6 @@ impl Element<'_> {
             Element::Link { .. } => "Link",
             Element::Collapsible { .. } => "Collapsible",
             Element::Color { .. } => "Color",
-            Element::Span { .. } => "Span",
-            Element::Div { .. } => "Div",
-            Element::Mark { .. } => "Mark",
-            Element::Insertion { .. } => "Insertion",
-            Element::Deletion { .. } => "Deletion",
             Element::Code { .. } => "Code",
             Element::LineBreak => "LineBreak",
             Element::LineBreaks { .. } => "LineBreaks",

--- a/test/bold-empty.json
+++ b/test/bold-empty.json
@@ -18,7 +18,7 @@
                         {
                             "element": "container",
                             "data": {
-                                "type": "bold",
+                                "type": "strong",
                                 "elements": [
                                 ]
                             }

--- a/test/bold-fail-paragraph.json
+++ b/test/bold-fail-paragraph.json
@@ -41,24 +41,24 @@
     "warnings": [
         {
             "token": "paragraph-break",
-            "rule": "bold",
+            "rule": "strong",
             "span": [6, 8],
             "kind": "rule-failed"
         },
         {
-            "token": "bold",
+            "token": "strong",
             "rule": "fallback",
             "span": [0, 2],
             "kind": "no-rules-match"
         },
         {
             "token": "input-end",
-            "rule": "bold",
+            "rule": "strong",
             "span": [14, 14],
             "kind": "end-of-input"
         },
         {
-            "token": "bold",
+            "token": "strong",
             "rule": "fallback",
             "span": [12, 14],
             "kind": "no-rules-match"

--- a/test/bold-fail.json
+++ b/test/bold-fail.json
@@ -33,12 +33,12 @@
     "warnings": [
         {
             "token": "input-end",
-            "rule": "bold",
+            "rule": "strong",
             "span": [11, 11],
             "kind": "end-of-input"
         },
         {
-            "token": "bold",
+            "token": "strong",
             "rule": "fallback",
             "span": [0, 2],
             "kind": "no-rules-match"

--- a/test/bold-italics-underline.json
+++ b/test/bold-italics-underline.json
@@ -10,7 +10,7 @@
                         {
                             "element": "container",
                             "data": {
-                                "type": "bold",
+                                "type": "strong",
                                 "elements": [
                                     {
                                         "element": "text",
@@ -23,7 +23,7 @@
                                     {
                                         "element": "container",
                                         "data": {
-                                            "type": "italics",
+                                            "type": "emphasis",
                                             "elements": [
                                                 {
                                                     "element": "text",

--- a/test/bold-italics.json
+++ b/test/bold-italics.json
@@ -10,7 +10,7 @@
                         {
                             "element": "container",
                             "data": {
-                                "type": "bold",
+                                "type": "strong",
                                 "elements": [
                                     {
                                         "element": "text",
@@ -23,7 +23,7 @@
                                     {
                                         "element": "container",
                                         "data": {
-                                            "type": "italics",
+                                            "type": "emphasis",
                                             "elements": [
                                                 {
                                                     "element": "text",

--- a/test/bold-nested.json
+++ b/test/bold-nested.json
@@ -10,7 +10,7 @@
                         {
                             "element": "container",
                             "data": {
-                                "type": "bold",
+                                "type": "strong",
                                 "elements": [
                                     {
                                         "element": "text",
@@ -23,7 +23,7 @@
                                     {
                                         "element": "container",
                                         "data": {
-                                            "type": "italics",
+                                            "type": "emphasis",
                                             "elements": [
                                                 {
                                                     "element": "text",

--- a/test/bold.json
+++ b/test/bold.json
@@ -10,7 +10,7 @@
                         {
                             "element": "container",
                             "data": {
-                                "type": "bold",
+                                "type": "strong",
                                 "elements": [
                                     {
                                         "element": "text",

--- a/test/css-multiline.json
+++ b/test/css-multiline.json
@@ -1,10 +1,10 @@
 {
-    "input": "[[css]]\nh1 {\n    margin-top: .7em\n    padding: 0;\n    font-weight: bold;\n}\n[[/css]]",
+    "input": "[[css]]\nh1 {\n    margin-top: .7em\n    padding: 0;\n    font-weight: strong;\n}\n[[/css]]",
     "tree": {
         "elements": [
         ],
         "styles": [
-            "h1 {\n    margin-top: .7em\n    padding: 0;\n    font-weight: bold;\n}"
+            "h1 {\n    margin-top: .7em\n    padding: 0;\n    font-weight: strong;\n}"
         ]
     },
     "warnings": [

--- a/test/del-alias.json
+++ b/test/del-alias.json
@@ -15,8 +15,9 @@
                             "element": "line-break"
                         },
                         {
-                            "element": "deletion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "deletion",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/del-newlines.json
+++ b/test/del-newlines.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "deletion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "deletion",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/del-style.json
+++ b/test/del-style.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "deletion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "deletion",
                                 "id": "banana",
                                 "class": "fruit",
                                 "style": "color: yellow;",

--- a/test/del-uppercase.json
+++ b/test/del-uppercase.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "deletion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "deletion",
                                 "id": "apple",
                                 "class": "fruit",
                                 "style": "color: red;",

--- a/test/del.json
+++ b/test/del.json
@@ -15,8 +15,9 @@
                             "element": "line-break"
                         },
                         {
-                            "element": "deletion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "deletion",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div-class.json
+++ b/test/div-class.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": "blockquote",
                                 "style": null,

--- a/test/div-empty-2.json
+++ b/test/div-empty-2.json
@@ -12,8 +12,9 @@
                             "data": "A"
                         },
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div-empty.json
+++ b/test/div-empty.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div-ending.json
+++ b/test/div-ending.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div-id.json
+++ b/test/div-id.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": "my-div",
                                 "class": null,
                                 "style": null,

--- a/test/div-multiline.json
+++ b/test/div-multiline.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div-nested-deep.json
+++ b/test/div-nested-deep.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,
@@ -24,8 +25,9 @@
                                                     "data": "A"
                                                 },
                                                 {
-                                                    "element": "div",
+                                                    "element": "styled-container",
                                                     "data": {
+                                                        "type": "div",
                                                         "id": null,
                                                         "class": null,
                                                         "style": null,
@@ -40,8 +42,9 @@
                                                                             "data": "B"
                                                                         },
                                                                         {
-                                                                            "element": "div",
+                                                                            "element": "styled-container",
                                                                             "data": {
+                                                                                "type": "div",
                                                                                 "id": null,
                                                                                 "class": null,
                                                                                 "style": null,
@@ -56,8 +59,9 @@
                                                                                                     "data": "C"
                                                                                                 },
                                                                                                 {
-                                                                                                    "element": "div",
+                                                                                                    "element": "styled-container",
                                                                                                     "data": {
+                                                                                                        "type": "div",
                                                                                                         "id": null,
                                                                                                         "class": null,
                                                                                                         "style": null,

--- a/test/div-nested.json
+++ b/test/div-nested.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,
@@ -22,7 +23,7 @@
                                                 {
                                                     "element": "container",
                                                     "data": {
-                                                        "type": "bold",
+                                                        "type": "strong",
                                                         "elements": [
                                                             {
                                                                 "element": "text",
@@ -40,8 +41,9 @@
                                                     "data": "Cherry"
                                                 },
                                                 {
-                                                    "element": "div",
+                                                    "element": "styled-container",
                                                     "data": {
+                                                        "type": "div",
                                                         "id": null,
                                                         "class": null,
                                                         "style": null,

--- a/test/div-paragraphs.json
+++ b/test/div-paragraphs.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div-style.json
+++ b/test/div-style.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": "display: flex",

--- a/test/div.json
+++ b/test/div.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div2-class.json
+++ b/test/div2-class.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": "blockquote",
                                 "style": null,

--- a/test/div2-empty-2.json
+++ b/test/div2-empty-2.json
@@ -12,8 +12,9 @@
                             "data": "A"
                         },
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div2-empty.json
+++ b/test/div2-empty.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div2-ending.json
+++ b/test/div2-ending.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div2-id.json
+++ b/test/div2-id.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": "my-div",
                                 "class": null,
                                 "style": null,

--- a/test/div2-multiline.json
+++ b/test/div2-multiline.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/div2-nested-deep.json
+++ b/test/div2-nested-deep.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,
@@ -19,8 +20,9 @@
                                         "data": "A"
                                     },
                                     {
-                                        "element": "div",
+                                        "element": "styled-container",
                                         "data": {
+                                            "type": "div",
                                             "id": null,
                                             "class": null,
                                             "style": null,
@@ -30,8 +32,9 @@
                                                     "data": "B"
                                                 },
                                                 {
-                                                    "element": "div",
+                                                    "element": "styled-container",
                                                     "data": {
+                                                        "type": "div",
                                                         "id": null,
                                                         "class": null,
                                                         "style": null,
@@ -41,8 +44,9 @@
                                                                 "data": "C"
                                                             },
                                                             {
-                                                                "element": "div",
+                                                                "element": "styled-container",
                                                                 "data": {
+                                                                    "type": "div",
                                                                     "id": null,
                                                                     "class": null,
                                                                     "style": null,

--- a/test/div2-nested.json
+++ b/test/div2-nested.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,
@@ -17,7 +18,7 @@
                                     {
                                         "element": "container",
                                         "data": {
-                                            "type": "bold",
+                                            "type": "strong",
                                             "elements": [
                                                 {
                                                     "element": "text",
@@ -35,8 +36,9 @@
                                         "data": "Cherry"
                                     },
                                     {
-                                        "element": "div",
+                                        "element": "styled-container",
                                         "data": {
+                                            "type": "div",
                                             "id": null,
                                             "class": null,
                                             "style": null,

--- a/test/div2-style.json
+++ b/test/div2-style.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": "display: flex",

--- a/test/div2.json
+++ b/test/div2.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "div",
+                            "element": "styled-container",
                             "data": {
+                                "type": "div",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/ins-alias.json
+++ b/test/ins-alias.json
@@ -15,8 +15,9 @@
                             "element": "line-break"
                         },
                         {
-                            "element": "insertion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "insertion",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/ins-newlines.json
+++ b/test/ins-newlines.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "insertion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "insertion",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/ins-style.json
+++ b/test/ins-style.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "insertion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "insertion",
                                 "id": "banana",
                                 "class": "fruit",
                                 "style": "color: yellow;",

--- a/test/ins-uppercase.json
+++ b/test/ins-uppercase.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "insertion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "insertion",
                                 "id": "apple",
                                 "class": "fruit",
                                 "style": "color: red;",

--- a/test/ins.json
+++ b/test/ins.json
@@ -15,8 +15,9 @@
                             "element": "line-break"
                         },
                         {
-                            "element": "insertion",
+                            "element": "styled-container",
                             "data": {
+                                "type": "insertion",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/italics-empty.json
+++ b/test/italics-empty.json
@@ -18,7 +18,7 @@
                         {
                             "element": "container",
                             "data": {
-                                "type": "italics",
+                                "type": "emphasis",
                                 "elements": [
                                 ]
                             }

--- a/test/italics-fail-paragraph.json
+++ b/test/italics-fail-paragraph.json
@@ -41,24 +41,24 @@
     "warnings": [
         {
             "token": "paragraph-break",
-            "rule": "italics",
+            "rule": "emphasis",
             "span": [6, 8],
             "kind": "rule-failed"
         },
         {
-            "token": "italics",
+            "token": "emphasis",
             "rule": "fallback",
             "span": [0, 2],
             "kind": "no-rules-match"
         },
         {
             "token": "input-end",
-            "rule": "italics",
+            "rule": "emphasis",
             "span": [17, 17],
             "kind": "end-of-input"
         },
         {
-            "token": "italics",
+            "token": "emphasis",
             "rule": "fallback",
             "span": [15, 17],
             "kind": "no-rules-match"

--- a/test/italics-fail.json
+++ b/test/italics-fail.json
@@ -33,12 +33,12 @@
     "warnings": [
         {
             "token": "input-end",
-            "rule": "italics",
+            "rule": "emphasis",
             "span": [14, 14],
             "kind": "end-of-input"
         },
         {
-            "token": "italics",
+            "token": "emphasis",
             "rule": "fallback",
             "span": [0, 2],
             "kind": "no-rules-match"

--- a/test/italics.json
+++ b/test/italics.json
@@ -10,7 +10,7 @@
                         {
                             "element": "container",
                             "data": {
-                                "type": "italics",
+                                "type": "emphasis",
                                 "elements": [
                                     {
                                         "element": "text",

--- a/test/mark-alias.json
+++ b/test/mark-alias.json
@@ -16,8 +16,9 @@
                             "data": " "
                         },
                         {
-                            "element": "mark",
+                            "element": "styled-container",
                             "data": {
+                                "type": "mark",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/mark-newlines.json
+++ b/test/mark-newlines.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "mark",
+                            "element": "styled-container",
                             "data": {
+                                "type": "mark",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/mark-style.json
+++ b/test/mark-style.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "mark",
+                            "element": "styled-container",
                             "data": {
+                                "type": "mark",
                                 "id": "banana",
                                 "class": "fruit",
                                 "style": "color: yellow;",

--- a/test/mark-uppercase.json
+++ b/test/mark-uppercase.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "mark",
+                            "element": "styled-container",
                             "data": {
+                                "type": "mark",
                                 "id": "apple",
                                 "class": "fruit",
                                 "style": "color: red;",

--- a/test/mark.json
+++ b/test/mark.json
@@ -16,8 +16,9 @@
                             "data": " "
                         },
                         {
-                            "element": "mark",
+                            "element": "styled-container",
                             "data": {
+                                "type": "mark",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/raw-token.json
+++ b/test/raw-token.json
@@ -1,5 +1,5 @@
 {
-    "input": "not @@**@@ bold",
+    "input": "not @@**@@ strong",
     "tree": {
         "elements": [
             {
@@ -25,7 +25,7 @@
                         },
                         {
                             "element": "text",
-                            "data": "bold"
+                            "data": "strong"
                         }
                     ]
                 }

--- a/test/span-empty.json
+++ b/test/span-empty.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/span-newlines-2.json
+++ b/test/span-newlines-2.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/span-newlines.json
+++ b/test/span-newlines.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/span-style.json
+++ b/test/span-style.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": "banana",
                                 "class": "fruit",
                                 "style": "color: yellow;",

--- a/test/span-uppercase.json
+++ b/test/span-uppercase.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": "apple",
                                 "class": "fruit",
                                 "style": "color: red;",

--- a/test/span.json
+++ b/test/span.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/span2-empty.json
+++ b/test/span2-empty.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/span2-newlines-2.json
+++ b/test/span2-newlines-2.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/span2-newlines.json
+++ b/test/span2-newlines.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": null,
                                 "class": null,
                                 "style": null,

--- a/test/span2-style.json
+++ b/test/span2-style.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": "banana",
                                 "class": "fruit",
                                 "style": "color: yellow;",

--- a/test/span2-uppercase.json
+++ b/test/span2-uppercase.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": "apple",
                                 "class": "fruit",
                                 "style": "color: red;",

--- a/test/span2.json
+++ b/test/span2.json
@@ -8,8 +8,9 @@
                     "type": "paragraph",
                     "elements": [
                         {
-                            "element": "span",
+                            "element": "styled-container",
                             "data": {
+                                "type": "span",
                                 "id": null,
                                 "class": null,
                                 "style": null,


### PR DESCRIPTION
We now have a number of elements which permit `id`, `class`, `style`, and simply contain a list of elements, like a `Container`.

This PR adds `StyledContainer`, to avoid code duplication between `Element`s which simply follow this pattern.

Also renames "bold" to "strong" and "italics" to "emphasis" since these are the HTML tags outputted.